### PR TITLE
fix conversion error in stop.c

### DIFF
--- a/util/stop.c
+++ b/util/stop.c
@@ -148,7 +148,7 @@ char *nlopt_vsprintf(char *p, const char *format, va_list ap)
         /* C99 vsnprintf returns the required number of bytes (excluding \0)
            if the buffer is too small; older versions (e.g. MS) return -1 */
         len = ret >= 0 ? (size_t)(ret + 1) : (len*3)>>1;
-        p = realloc(p, len);
+        p = (char *) realloc(p, len);
         if (!p) abort();
     }
     return p;


### PR DESCRIPTION
hi,

I got this error introduced by 61fe516 when compiling git head with gcc:

```
make[2]: Entering directory '/home/schueller/projects/nlopt/build/util'
/bin/sh ../libtool  --tag=CC   --mode=compile g++ -DHAVE_CONFIG_H -I. -I../../util -I..  -I../../api   -g -O2 -Wall -W -Wcast-qual -Wpointer-arith -Wcast-align -Wno-long-long -pedantic -Wshadow -Wwrite-strings -Wredundant-decls -Wundef -Wconversion -MT stop.lo -MD -MP -MF .deps/stop.Tpo -c -o stop.lo ../../util/stop.c
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I../../util -I.. -I../../api -g -O2 -Wall -W -Wcast-qual -Wpointer-arith -Wcast-align -Wno-long-long -pedantic -Wshadow -Wwrite-strings -Wredundant-decls -Wundef -Wconversion -MT stop.lo -MD -MP -MF .deps/stop.Tpo -c ../../util/stop.c  -fPIC -DPIC -o .libs/stop.o
../../util/stop.c: In function ‘char* nlopt_vsprintf(char*, const char*, __va_list_tag*)’:
../../util/stop.c:151:20: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
         p = realloc(p, len);
                    ^
Makefile:426: recipe for target 'stop.lo' failed
```

It should be the same as line 144: https://github.com/jschueller/nlopt/blob/d88458176f694c7c38e2f75c7e3da9e65db6812c/util/stop.c#L144