### PR TITLE
Chain build rules for guile and python bindings to avoid race conditions in parallel builds

### DIFF
--- a/swig/Makefile.am
+++ b/swig/Makefile.am
@@ -1,4 +1,4 @@
-SWIG_SRC = nlopt.i nlopt-exceptions.i nlopt-enum-renames.i 
+SWIG_SRC = nlopt.i nlopt-exceptions.i nlopt-enum-renames.i
 EXTRA_DIST = $(SWIG_SRC) nlopt-guile.i nlopt-python.i nlopt.scm.in nlopt.py numpy.i
 
 BUILT_SOURCES = nlopt-guile.cpp nlopt-python.cpp nlopt-enum-renames.i nlopt.scm.in
@@ -42,13 +42,17 @@ lib_LTLIBRARIES = $(guilelib)
 
 if MAINTAINER_MODE
 
-nlopt-guile.cpp nlopt.scm.in: $(SWIG_SRC) nlopt-guile.i $(HDR)
+nlopt-guile.cpp: $(SWIG_SRC) nlopt-guile.i $(HDR)
 	swig -I$(top_srcdir)/api -outdir $(builddir) -c++ -guile -scmstub -o $@ $(srcdir)/nlopt.i
 	rm -f nlopt.scm.in
 	mv nlopt.scm nlopt.scm.in
 
-nlopt-python.cpp nlopt.py: $(SWIG_SRC) nlopt-python.i numpy.i $(HDR)
+nlopt.scm.in: nlopt-guile.cpp
+
+nlopt-python.cpp: $(SWIG_SRC) nlopt-python.i numpy.i $(HDR)
 	swig -I$(top_srcdir)/api -outdir $(builddir) -c++ -python -o $@ $(srcdir)/nlopt.i
+
+nlopt.py: nlopt-python.cpp
 
 nlopt-enum-renames.i: $(top_srcdir)/api/nlopt.h
 	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; egrep 'NLOPT_[LG][DN]|NLOPT_AUGLAG|NLOPT_G_MLSL|NLOPT_NUM_ALGORITHMS' $(top_srcdir)/api/nlopt.h | sed 's/NLOPT_//g' |tr -d ' ' |tr '/' ',' |tr '=' ',' |cut -d, -f1 |while read name; do echo "%rename(NLOPT_$$name) nlopt::$$name;"; done; egrep 'NLOPT_[A-Z_]* =' $(top_srcdir)/api/nlopt.h | egrep -v 'NLOPT_[LG][DN]|NLOPT_AUGLAG|NLOPT_G_MLSL' | sed 's/NLOPT_//g' |tr -d ' ' |cut -d'=' -f1 | while read name; do echo "%rename(NLOPT_$$name) nlopt::$$name;"; done) > $@


### PR DESCRIPTION
Prior ro this patch, I would see errors when building in parallel when the rule for nlopt.scm.in and nlopt-guild.cpp were run in parallel (actually the same rule), causing a race condition on the rename of nlopt.scm to nlopt.scm.in:

swig -I../api -outdir . -c++ -guile -scmstub -o nlopt-guile.cpp ./nlopt.i
swig -I../api -outdir . -c++ -python -o nlopt-python.cpp ./nlopt.i
swig -I../api -outdir . -c++ -guile -scmstub -o nlopt.scm.in ./nlopt.i
../api/nlopt.hpp:122: Warning 401: Nothing known about base class 'std::runtime_error'. Ignored.
../api/nlopt.hpp:127: Warning 401: Nothing known about base class 'std::runtime_error'. Ignored.
../api/nlopt.hpp:122: Warning 401: Nothing known about base class 'std::runtime_error'. Ignored.
../api/nlopt.hpp:127: Warning 401: Nothing known about base class 'std::runtime_error'. Ignored.
../api/nlopt.hpp:296: Warning 503: Can't wrap 'operator =' unless renamed to a valid identifier.
../api/nlopt.hpp:296: Warning 503: Can't wrap 'operator =' unless renamed to a valid identifier.
rm -f nlopt.scm.in
mv nlopt.scm nlopt.scm.in
rm -f nlopt.scm.in
mv nlopt.scm nlopt.scm.in
mv: cannot stat ‘nlopt.scm’: No such file or directory
make[2]: *** [nlopt-guile.cpp] Error 1
make[2]: *** Waiting for unfinished jobs....
../api/nlopt.hpp:296: Warning 362: operator= ignored
make[2]: Leaving directory `/home/sammy/git/nlopt/swig'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/sammy/git/nlopt'
make: *** [all] Error 2

