### PR TITLE
add missing linking for C++

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,11 @@ endif
 SUBDIRS = util direct cdirect $(CXX_DIRS) praxis luksan crs mlsl mma cobyla newuoa neldermead auglag bobyqa isres slsqp esch api . octave test swig
 EXTRA_DIST = autogen.sh nlopt.pc.in m4 CMakeLists.txt config.cmake.h.in
 
-libnlopt@NLOPT_SUFFIX@_la_SOURCES = 
+libnlopt@NLOPT_SUFFIX@_la_SOURCES =
+if WITH_CXX
+# Dummy C++ source to cause C++ linking
+nodist_EXTRA_libnlopt@NLOPT_SUFFIX@_la_SOURCES = dummy.cxx
+endif
 libnlopt@NLOPT_SUFFIX@_la_LIBADD = direct/libdirect.la			\
 cdirect/libcdirect.la $(CXX_LIBS) praxis/libpraxis.la \
 luksan/libluksan.la crs/libcrs.la mlsl/libmlsl.la mma/libmma.la		\
@@ -19,12 +23,7 @@ cobyla/libcobyla.la newuoa/libnewuoa.la neldermead/libneldermead.la	\
 auglag/libauglag.la bobyqa/libbobyqa.la isres/libisres.la		\
 slsqp/libslsqp.la esch/libesch.la api/libapi.la util/libutil.la
 
-if WITH_CXX
-libnlopt@NLOPT_SUFFIX@_la_LDFLAGS = -version-info @SHARED_VERSION_INFO@
-else
 libnlopt@NLOPT_SUFFIX@_la_LDFLAGS = -no-undefined -version-info @SHARED_VERSION_INFO@
-endif
-
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = nlopt.pc
 

--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,7 @@ if test $have_python = yes; then
   fi
   AC_MSG_RESULT([${pinc:-unknown}])
   PYTHON_INCLUDES="$pinc"
+  PYTHON_LIBS=`$PYTHON_CONFIG --libs 2>/dev/null`
   save_CPPFLAGS=$CPPFLAGS
   CPPFLAGS="$CPPFLAGS $PYTHON_INCLUDES"
   AC_CHECK_HEADER([Python.h], [], [AC_MSG_WARN([disabling Python wrappers]) 
@@ -206,6 +207,7 @@ AC_SUBST(GUILE_INSTALL_DIR)
 AC_SUBST(GUILE_CPPFLAGS)
 AC_SUBST(GUILE_LIBS)
 AC_SUBST(PYTHON_INCLUDES)
+AC_SUBST(PYTHON_LIBS)
 AM_CONDITIONAL(WITH_GUILE, test x"$GUILE_CONFIG" != "xunknown")
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
 

--- a/swig/Makefile.am
+++ b/swig/Makefile.am
@@ -23,10 +23,9 @@ endif
 # Python wrapper
 
 _nlopt_la_SOURCES = nlopt-python.cpp
-_nlopt_la_LIBADD = ../libnlopt@NLOPT_SUFFIX@.la
+_nlopt_la_LIBADD = ../libnlopt@NLOPT_SUFFIX@.la $(PYTHON_LIBS)
 _nlopt_la_LDFLAGS = -module -version-info @SHARED_VERSION_INFO@
 _nlopt_la_CPPFLAGS = $(PYTHON_INCLUDES) -I$(top_srcdir)/api
-
 if WITH_PYTHON
 python_PYTHON = nlopt.py
 pyexec_LTLIBRARIES = _nlopt.la


### PR DESCRIPTION
When building the C++ library, some symbols were missing because libtool didn't use the right tag.
Also the python extension wasn't linked to the python libraries.