### PR TITLE
add cmake flag for testing, add common definitions file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,11 @@ list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
 option (WITH_CXX "enable cxx routines" OFF)
 option (BUILD_SHARED_LIBS "Build NLOPT as a shared library" ON)
-option (BUILD_PYTHON "build python bindings" ON)
-option (BUILD_OCTAVE "build octave bindings" ON)
-option (BUILD_MATLAB "build matlab bindings" ON)
-option (BUILD_GUILE "build guile bindings" ON)
+option (BUILD_PYTHON "build python bindings"  ON)
+option (BUILD_OCTAVE "build octave bindings"  ON)
+option (BUILD_MATLAB "build matlab bindings"  ON)
+option (BUILD_GUILE "build guile bindings"    ON)
+option (BUILD_TESTS "build tests?"           OFF)
 option (USE_SWIG "use SWIG to build bindings" ON)
 
 set (NLOPT_SUFFIX)
@@ -39,6 +40,7 @@ if (WITH_CXX OR BUILD_PYTHON)
   enable_language (CXX)
 endif ()
 
+include (${CMAKE_SOURCE_DIR}/cmake/common.cmake)
 
 # Offer the user the choice of overriding the installation directories
 set (INSTALL_LIB_DIR     lib${LIB_SUFFIX} CACHE PATH "Installation directory for libraries")

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,0 +1,35 @@
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+    
+string(ASCII 27 Esc)
+set(Green    "${Esc}[92m"     CACHE STRING "green color"    FORCE)
+set(Blue     "${Esc}[1;94m"   CACHE STRING "Blue color"     FORCE)
+set(BoldRed  "${Esc}[1;5;91m" CACHE STRING "bold-red color" FORCE)
+set(NoColor  "${Esc}[0m"      CACHE STRING "reset color"    FORCE)
+
+if(NOT WIN32)
+
+    execute_process(COMMAND   ${CMAKE_C_COMPILER}  -dumpversion   OUTPUT_VARIABLE   GCC_VERSION)
+    if(GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9)
+        set(STDLIBC  "-std=c++1y")
+    elseif(GCC_VERSION VERSION_EQUAL 4.8)
+        set(STDLIBC  "-std=c++11")
+    else()
+        set(STDLIBC  " ")
+    endif()
+    set(STDLIBCXX_FLAG  ${STDLIBC}  CACHE STRING "stdlibc++ flag")
+    message(STATUS "${Green}GCC_VERSION= ${GCC_VERSION} ")
+    message(STATUS " -std= flag: ${STDLIBCXX_FLAG}  ${NoColor} " )
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}   ${STDLIBCXX_FLAG} " )
+
+    execute_process( COMMAND  mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} )
+
+    enable_testing()
+    
+    if(BUILD_TESTS)
+        message(STATUS "${Blue} Testing enabled: run 'ctest -VV -N' to see list of tests available and their arguments. ${NoColor}")
+    endif()
+   
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,13 @@
 add_custom_target (tests)
 
+if(BUILD_TESTS)
+    set(TESTING_FLAG  "")
+else()
+    set(TESTING_FLAG EXCLUDE_FROM_ALL)
+endif()
+
 # have to add timer.c and mt19937ar.c as symbols are declared extern
-add_executable (testopt EXCLUDE_FROM_ALL testfuncs.c testfuncs.h testopt.cpp ${CMAKE_SOURCE_DIR}/util/timer.c ${CMAKE_SOURCE_DIR}/util/mt19937ar.c)
+add_executable (testopt ${TESTING_FLAG} testfuncs.c testfuncs.h testopt.cpp ${CMAKE_SOURCE_DIR}/util/timer.c ${CMAKE_SOURCE_DIR}/util/mt19937ar.c)
 target_link_libraries (testopt ${nlopt_lib})
 add_dependencies (tests testopt)
 


### PR DESCRIPTION
- added some cmake helper functionality . 
- added BUILD_TESTS flag to configure from gui .
- added ctest hint so one can see the nicely done matrix of tests available. 