### PR TITLE
Prevent a conditional jump based on uninitialized value in nlopt_create.

### DIFF
--- a/api/options.c
+++ b/api/options.c
@@ -98,11 +98,11 @@ nlopt_opt NLOPT_STDCALL nlopt_create(nlopt_algorithm algorithm, unsigned n)
 	  opt->errmsg = NULL;
 
 	  if (n > 0) {
-	       opt->lb = (double *) malloc(sizeof(double) * (n));
+	       opt->lb = (double *) calloc(n, sizeof(double));
 	       if (!opt->lb) goto oom;
-	       opt->ub = (double *) malloc(sizeof(double) * (n));
+	       opt->ub = (double *) calloc(n, sizeof(double));
 	       if (!opt->ub) goto oom;
-	       opt->xtol_abs = (double *) malloc(sizeof(double) * (n));
+	       opt->xtol_abs = (double *) calloc(n, sizeof(double));
 	       if (!opt->xtol_abs) goto oom;
 	       nlopt_set_lower_bounds1(opt, -HUGE_VAL);
 	       nlopt_set_upper_bounds1(opt, +HUGE_VAL);


### PR DESCRIPTION
`nlopt_set_lower_bounds1` reads from `opt->ub` before it has ever been written.

We caught this in our nightly memcheck CI build for RobotLocomotion/drake: https://drake-cdash.csail.mit.edu/viewDynamicAnalysisFile.php?id=14355

Contributes to RobotLocomotion/drake#3873

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stevengj/nlopt/89)
<!-- Reviewable:end -->
