### PR TITLE
Fix dllexport and dllimport for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,8 +239,8 @@ get_target_property (NLOPT_PRIVATE_INCLUDE_DIRS ${nlopt_lib} INCLUDE_DIRECTORIES
 target_include_directories (${nlopt_lib} INTERFACE "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/api>")
 
 if (BUILD_SHARED_LIBS)
-  target_compile_definitions (${nlopt_lib} INTERFACE -DNLOPT_DLL)
-  target_compile_definitions (${nlopt_lib} INTERFACE -DNLOPT_DLL_EXPORT)
+  target_compile_definitions (${nlopt_lib} PUBLIC -DNLOPT_DLL)
+  target_compile_definitions (${nlopt_lib} PRIVATE -DNLOPT_DLL_EXPORT)
 endif ()
 
 # pass -fPIC in case swig module is built with static library


### PR DESCRIPTION
This patch fixes the DLL exports and imports for Windows. If a shared library is built, NLOPT_DLL must be defined for the library itself and everything linking against it (PUBLIC) whereas NLOPT_DLL_EXPORT must only be defined for the library itself (PRIVATE).