### PR TITLE
Add postfixes for debug and static builds on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,19 @@ target_link_libraries (${nlopt_lib} ${M_LIBRARY})
 set_target_properties (${nlopt_lib} PROPERTIES SOVERSION 0)
 set_target_properties (${nlopt_lib} PROPERTIES VERSION 0.9.0)
 
+if (BUILD_SHARED_LIBS)
+  if (WIN32)
+    set_target_properties (${nlopt_lib} PROPERTIES DEBUG_POSTFIX d )
+  endif ()
+else ()
+  if (WIN32)
+    set_target_properties (${nlopt_lib} PROPERTIES DEBUG_POSTFIX sd )
+    set_target_properties (${nlopt_lib} PROPERTIES MINSIZEREL_POSTFIX s )
+    set_target_properties (${nlopt_lib} PROPERTIES RELEASE_POSTFIX s )
+    set_target_properties (${nlopt_lib} PROPERTIES RELWITHDEBINFO_POSTFIX s )
+  endif ()
+endif ()
+
 #==============================================================================
 # INCLUDE DIRECTORIES
 #==============================================================================


### PR DESCRIPTION
This patch adds a "d" postfix for debug builds (e.g., nloptd.lib and nloptd.dll) on Windows to enable the binaries for both debug and release builds to be installed at the same time as supported by the exported targets. It also adds a "s"/"sd" postfix for static builds (e.g., nlopts.lib and nloptsd.lib) to distinguish from shared builds.