### PR TITLE
Add namespace for CMake targets and add install include directories to target properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,7 @@ target_include_directories (${nlopt_lib} PRIVATE
   api)
 
 get_target_property (NLOPT_PRIVATE_INCLUDE_DIRS ${nlopt_lib} INCLUDE_DIRECTORIES)
-target_include_directories (${nlopt_lib} INTERFACE "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/api>")
+target_include_directories (${nlopt_lib} INTERFACE "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/api>" "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
 
 if (BUILD_SHARED_LIBS)
   target_compile_definitions (${nlopt_lib} PUBLIC -DNLOPT_DLL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,16 +320,17 @@ set (CPACK_SOURCE_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${NLOPT_VERSION_STRING
 include (CPack)
 
 # configuration files
-export (TARGETS ${nlopt_lib} FILE ${PROJECT_BINARY_DIR}/NLoptLibraryDepends.cmake)
+export (TARGETS ${nlopt_lib} NAMESPACE NLopt:: FILE ${PROJECT_BINARY_DIR}/NLoptLibraryDepends.cmake)
 
 # Install the export set for use with the install-tree
 install(EXPORT NLoptLibraryDepends
+        NAMESPACE NLopt::
         DESTINATION ${RELATIVE_INSTALL_CMAKE_DIR}
         COMPONENT Development)
 
 # Create a NLOPTConfig.cmake file for the use from the install tree
 # and install it
-set (NLOPT_LIBRARIES ${nlopt_lib})
+set (NLOPT_LIBRARIES "NLopt::${nlopt_lib}")
 
 set (NLOPT_CMAKE_DIR "${INSTALL_CMAKE_DIR}")
 file (RELATIVE_PATH rel_include_dir "${NLOPT_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")


### PR DESCRIPTION
This patch adds a namespace to exported CMake targets as recommended by CMake for imported targets (https://cmake.org/cmake/help/v3.9/manual/cmake-developer.7.html#a-sample-find-module).
It also adds the location of the include directory at install time to the target properties to enable target-based linking.