### PR TITLE
Install PDB file with debug information when using Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ install ( TARGETS ${nlopt_lib}
           ARCHIVE DESTINATION ${RELATIVE_INSTALL_LIB_DIR}
         )
 
+if (MSVC AND BUILD_SHARED_LIBS AND NOT CMAKE_VERSION VERSION_LESS 3.1)
+  install (FILES $<TARGET_PDB_FILE:${nlopt_lib}> DESTINATION ${RELATIVE_INSTALL_BIN_DIR} CONFIGURATIONS Debug RelWithDebInfo COMPONENT Debug)
+endif ()
+
 add_subdirectory (api)
 
 if (BUILD_PYTHON)


### PR DESCRIPTION
This patch installs the PDB file with debug symbols generated by MSVC into the installation's bin directory when building shared libraries and using the Debug or RelWithDebInfo configuration. This is only supported by CMake >= 3.1.