### PR TITLE
Prefix cmake options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DWITH_CXX=ON ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_CXX=ON ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DWITH_CXX=ON -DBUILD_PYTHON=OFF -DBUILD_OCTAVE=OFF -DBUILD_GUILE=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-i686-w64-mingw32.cmake ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_CXX=ON -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-i686-w64-mingw32.cmake ..
         - make install -j2
         - rm -rf * ~/.local
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DWITH_CXX=ON -DBUILD_PYTHON=OFF -DBUILD_OCTAVE=OFF -DBUILD_GUILE=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_CXX=ON -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..
         - make install -j2
 
     - os: osx
@@ -40,5 +40,5 @@ matrix:
         - brew install swig octave || echo "nope"
       script:
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DWITH_CXX=ON -DPYTHON_EXECUTABLE=/usr/bin/python ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_CXX=ON -DPYTHON_EXECUTABLE=/usr/bin/python ..
         - make install && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,16 @@ project (nlopt)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-option (WITH_CXX "enable cxx routines" OFF)
+option (NLOPT_CXX "enable cxx routines" OFF)
 option (BUILD_SHARED_LIBS "Build NLopt as a shared library" ON)
-option (BUILD_PYTHON "build python bindings" ON)
-option (BUILD_OCTAVE "build octave bindings" ON)
-option (BUILD_MATLAB "build matlab bindings" ON)
-option (BUILD_GUILE "build guile bindings" ON)
-option (USE_SWIG "use SWIG to build bindings" ON)
+option (NLOPT_PYTHON "build python bindings" ON)
+option (NLOPT_OCTAVE "build octave bindings" ON)
+option (NLOPT_MATLAB "build matlab bindings" ON)
+option (NLOPT_GUILE "build guile bindings" ON)
+option (NLOPT_SWIG "use SWIG to build bindings" ON)
 
 set (NLOPT_SUFFIX)
-if (WITH_CXX)
+if (NLOPT_CXX)
   set (NLOPT_SUFFIX _cxx)
 endif ()
 
@@ -136,7 +136,7 @@ if (WITH_THREADLOCAL AND NOT DEFINED HAVE_THREAD_LOCAL_STORAGE)
   endforeach()
 endif ()
 
-if (WITH_CXX OR BUILD_PYTHON OR BUILD_GUILE OR BUILD_OCTAVE)
+if (NLOPT_CXX OR NLOPT_PYTHON OR NLOPT_GUILE OR NLOPT_OCTAVE)
   check_cxx_symbol_exists (_LIBCPP_VERSION string SYSTEM_HAS_LIBCPP)
   if (SYSTEM_HAS_LIBCPP)
     check_cxx_compiler_flag ("-std=c++11" SUPPORTS_STDCXX11)
@@ -197,7 +197,7 @@ set (NLOPT_SOURCES
   util/mt19937ar.c util/sobolseq.c util/soboldata.h util/timer.c util/stop.c util/nlopt-util.h util/redblack.c util/redblack.h util/qsort_r.c util/rescale.c
 )
 
-if (WITH_CXX)
+if (NLOPT_CXX)
   list (APPEND NLOPT_SOURCES stogo/global.cc stogo/linalg.cc stogo/local.cc stogo/stogo.cc stogo/tools.cc stogo/global.h stogo/linalg.h stogo/local.h stogo/stogo_config.h stogo/stogo.h stogo/tools.h)
 endif ()
 
@@ -265,7 +265,7 @@ endif ()
 
 add_subdirectory (api)
 
-if (BUILD_PYTHON)
+if (NLOPT_PYTHON)
   find_package (PythonInterp)
   find_package (PythonLibs)
   find_package (NumPy)
@@ -283,21 +283,21 @@ if (NOT DEFINED INSTALL_PYTHON_DIR AND PYTHONINTERP_FOUND)
 
 endif ()
 
-if (BUILD_GUILE)
+if (NLOPT_GUILE)
   find_package (Guile)
 endif ()
 
-if (USE_SWIG)
+if (NLOPT_SWIG)
   find_package (SWIG)
 endif ()
 
 add_subdirectory (swig)
 
-if (BUILD_OCTAVE)
+if (NLOPT_OCTAVE)
   find_package (Octave)
 endif ()
 
-if (BUILD_MATLAB)
+if (NLOPT_MATLAB)
   find_package (Matlab)
 endif ()
 

--- a/api/general.c
+++ b/api/general.c
@@ -42,7 +42,7 @@ static const char nlopt_algorithm_names[NLOPT_NUM_ALGORITHMS][256] = {
      "Unscaled Randomized DIRECT-L (global, no-derivative)",
      "Original DIRECT version (global, no-derivative)",
      "Original DIRECT-L version (global, no-derivative)",
-#ifdef WITH_CXX
+#ifdef NLOPT_CXX
      "StoGO (global, derivative-based)",
      "StoGO with randomized search (global, derivative-based)",
 #else

--- a/api/optimize.c
+++ b/api/optimize.c
@@ -31,7 +31,7 @@
 #include "praxis.h"
 #include "direct.h"
 
-#ifdef WITH_CXX
+#ifdef NLOPT_CXX
 #  include "stogo.h"
 #endif
 
@@ -505,7 +505,7 @@ static nlopt_result nlopt_optimize_(nlopt_opt opt, double *x, double *minf)
 
 	 case NLOPT_GD_STOGO:
 	 case NLOPT_GD_STOGO_RAND:
-#ifdef WITH_CXX
+#ifdef NLOPT_CXX
               if (!finite_domain(n, lb, ub))
                   RETURN_ERR(NLOPT_INVALID_ARGS, opt,
                              "finite domain required for global algorithm");

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,6 @@ install:
 build_script:
   - echo Running cmake...
   - cd c:\projects\nlopt
-  - cmake -G "%CMAKE_PLATFORM%" -DWITH_CXX=ON -DCMAKE_INSTALL_PREFIX="C:\projects\nlopt\install" .
+  - cmake -G "%CMAKE_PLATFORM%" -DNLOPT_CXX=ON -DCMAKE_INSTALL_PREFIX="C:\projects\nlopt\install" .
   - cmake --build . --config %Configuration% --target install
   - ctest -C %Configuration% --output-on-failure --timeout 100

--- a/doc/docs/NLopt_Installation.md
+++ b/doc/docs/NLopt_Installation.md
@@ -141,7 +141,7 @@ NLopt with C++ algorithms
 NLopt, as-is, is callable from C, C++, and Fortran, with optional Matlab and GNU Octave plugins (and even installs an `nlopt.hpp` C++ header file to allow you to call it in a more C++ style). By default, it includes only subroutines written in C (or written in Fortran and converted to C), to simplify linking. If you configure with:
 
 ```
-cmake -DWITH_CXX=ON .
+cmake -DNLOPT_CXX=ON .
 ```
 
 

--- a/nlopt_config.h.in
+++ b/nlopt_config.h.in
@@ -148,7 +148,7 @@
 #undef VERSION
 
 /* Define if compiled including C++-based routines */
-#cmakedefine WITH_CXX
+#cmakedefine NLOPT_CXX
 
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach (algo_index RANGE 29)# 42
   foreach (obj_index RANGE 1)# 21
     set (enable_ TRUE)
     # cxx stogo
-    if (NOT WITH_CXX)
+    if (NOT NLOPT_CXX)
       if (algo_index STREQUAL 8 OR algo_index STREQUAL 9)
         set (enable_ FALSE)
       endif ()


### PR DESCRIPTION
NLopt is used as a git submodule, this allows not to confuse options of the parent project.

cc @jdumas