### PR TITLE
Fixed Matlab find_package issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ if (NLOPT_OCTAVE)
 endif ()
 
 if (NLOPT_MATLAB)
-  find_package (Matlab)
+  find_package (Matlab COMPONENTS MX_LIBRARY REQUIRED)
 endif ()
 
 if (OCTAVE_FOUND OR Matlab_FOUND)


### PR DESCRIPTION
To link Matlab's C/C++ Matrix Library (libmx.dll in Windows), find_package(Matlab) line in CMakeLists.txt needs to specify the MX_LIBRARY component as required.