### PR TITLE
fix code formatting for including headers

### DIFF
--- a/doc/docs/NLopt_Tutorial.md
+++ b/doc/docs/NLopt_Tutorial.md
@@ -32,8 +32,8 @@ Example in C/C++
 
 To implement the above example in C or C++, we would first do:
 
-`#include `<math.h>
-`#include `<nlopt.h>
+`#include <math.h>`
+`#include <nlopt.h>`
 
 to include the NLopt header file as well as the standard math header file (needed for things like the `sqrt` function and the `HUGE_VAL` constant), then we would define our objective function as:
 

--- a/doc/docs/NLopt_Tutorial.md
+++ b/doc/docs/NLopt_Tutorial.md
@@ -32,8 +32,10 @@ Example in C/C++
 
 To implement the above example in C or C++, we would first do:
 
-`#include <math.h>`
-`#include <nlopt.h>`
+```c
+#include <math.h>
+#include <nlopt.h>
+```
 
 to include the NLopt header file as well as the standard math header file (needed for things like the `sqrt` function and the `HUGE_VAL` constant), then we would define our objective function as:
 


### PR DESCRIPTION
On the documentation site the include header code is not shown correctly. The markdown formatting issue is fixed in this PR.

![screen shot 2017-10-14 at 9 40 25 pm](https://user-images.githubusercontent.com/7845831/31576174-556fd71e-b128-11e7-8131-94002c20e1de.png)
