### PR TITLE
Add virtual destructor to class Global (in algs/stogo/)

### DIFF
--- a/src/algs/stogo/global.h
+++ b/src/algs/stogo/global.h
@@ -58,6 +58,9 @@ public:
   }
 				   
   Global(RTBox, Pobj, Pgrad, GlobalParams);
+  
+  virtual ~Global() = default;
+
 //  Global& operator=(const Global &);
 
   void Search(int, RCRVector);

--- a/src/algs/stogo/global.h
+++ b/src/algs/stogo/global.h
@@ -59,7 +59,7 @@ public:
 				   
   Global(RTBox, Pobj, Pgrad, GlobalParams);
   
-  virtual ~Global() = default;
+  virtual ~Global(){};
 
 //  Global& operator=(const Global &);
 


### PR DESCRIPTION
Having a base class without virtual destructor could result in undefined behavior (most possibly in a memory leak) when deleting an instance through a base class pointer.

Get rid of the following warnings: 
```
In file included from /home/dave/gitrepos/nlopt/src/algs/stogo/stogo.cc:5:
/home/dave/gitrepos/nlopt/src/algs/stogo/global.h:39:7: warning: 'Global' has virtual functions but
      non-virtual destructor [-Wnon-virtual-dtor]
class Global: public GlobalParams {
      ^
/home/dave/gitrepos/nlopt/src/algs/stogo/stogo.cc:7:7: warning: 'MyGlobal' has virtual functions but
      non-virtual destructor [-Wnon-virtual-dtor]
class MyGlobal : public Global {
      ^
```
