### PR TITLE
Python 3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ endif ()
 add_subdirectory (src/api)
 
 if (NLOPT_PYTHON)
-  find_package (PythonInterp)
+  find_package (PythonInterp ${NLOPT_PYTHON_VERSION})
   find_package (PythonLibs)
   find_package (NumPy)
 endif ()


### PR DESCRIPTION
This pull requests allows nlopt to be built with Python3 over the command line. 
```bash
git clone git://github.com/stevengj/nlopt
cd nlopt
mkdir build
cd build
cmake -DNLOPT_PYTHON_VERSION=3 ..
make
sudo make install
```
If cmake is called with `cmake -DNLOPT_PYTHON_VERSION=2 ..` or `cmake ..` the wrapper is built for Python 2.
I made the these with Ubuntu 16.04.

Unfortunately this patch doesn't work for reconfigurations. If `cmake -DNLOPT_PYTHON_VERSION=2 ..` is run first and then the project is reconfigured with `cmake -DNLOPT_PYTHON_VERSION=3 ..` errors are thrown because of the caching behavior of _find_package (PythonInterp)._ This issue would also appear if the cmake gui is used (first press the _Configure_ button change the setting and then apply the changes by pressing _Configure_ again and then _Generate_). Therefore I haven't added the option to change the Python version in the cmake gui.

A possibility to overcome this issue is to delete the cache of the variables created by _find_package (PythonInterp)_ and _find_package (PythonLibs)._ I attached the [CMakeLists.txt](https://github.com/stevengj/nlopt/files/2190272/CMakeLists.txt) file with this behavior to this post (see lines 33-34 and 273-291). But this feels a bit wrong because it would also overwrite _PYTHON_LIBRARY_ and _PYTHON_INCLUDE_DIR_ set by the user.

A third possibility would be to use the newer modules _FindPython2_ and _FindPython3_
 because _FindPythonInterp_ and _FindPythonLibs_ are already deprecated. But those modules aren't available in older cmake versions like mine shipped with Ubuntu 16.04.

I decided to create this pull request with the first conservative option. But I can change this pull request if another option would be better.