### PR TITLE
Add -Wall and -Wextra, fix lots of warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DCMAKE_C_FLAGS='-Wall -Wextra -Werror' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Werror' ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DCMAKE_C_FLAGS='-Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
         - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-i686-w64-mingw32.cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DCMAKE_C_FLAGS='-Wall -Wextra -Werror' -DCMAKE_CXX_FLAGS='-Wall -Wextra -Werror' ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
         - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-i686-w64-mingw32.cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,6 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
-set (CMAKE_C_FLAGS "-Wall -Wextra ${CMAKE_C_FLAGS}")
-set (CMAKE_CXX_FLAGS "-Wall -Wextra ${CMAKE_CXX_FLAGS}")
-
 include (CheckIncludeFiles)
 include (CheckFunctionExists)
 include (CheckTypeSize)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
+set (CMAKE_C_FLAGS "-Wall -Wextra ${CMAKE_C_FLAGS}")
+set (CMAKE_CXX_FLAGS "-Wall -Wextra ${CMAKE_CXX_FLAGS}")
+
 include (CheckIncludeFiles)
 include (CheckFunctionExists)
 include (CheckTypeSize)

--- a/src/algs/ags/local_optimizer.cc
+++ b/src/algs/ags/local_optimizer.cc
@@ -32,7 +32,8 @@ Trial HookeJeevesOptimizer::Optimize(std::shared_ptr<IGOProblem<double>> problem
 
   int k = 0, i=0;
   bool needRestart = true;
-  double currentFValue, nextFValue;
+  /* currentFvalue will be initialized below, init here to avoid maybe-uninitialized warning */
+  double currentFValue = 0.0, nextFValue;
 
   while (i < MAX_LOCAL_ITERATIONS_NUMBER)	{
     i++;

--- a/src/algs/ags/solver.cc
+++ b/src/algs/ags/solver.cc
@@ -58,7 +58,7 @@ namespace
           right[i] = mRightBound[i];
         }
       }
-      int GetOptimumPoint(double* y) const {return 0;}
+      int GetOptimumPoint(double* y) const {(void) y; return 0;}
       double GetOptimumValue() const {return 0;}
     };
 }

--- a/src/algs/ags/solver.cc
+++ b/src/algs/ags/solver.cc
@@ -58,7 +58,7 @@ namespace
           right[i] = mRightBound[i];
         }
       }
-      int GetOptimumPoint(double* y) const {(void) y; return 0;}
+      int GetOptimumPoint(double*) const {return 0;}
       double GetOptimumValue() const {return 0;}
     };
 }

--- a/src/algs/bobyqa/bobyqa.c
+++ b/src/algs/bobyqa/bobyqa.c
@@ -24,7 +24,7 @@ static void update_(int *n, int *npt, double *bmat,
     double d__1, d__2, d__3;
 
     /* Local variables */
-    int i__, j, k, jl, jp;
+    int i__, j, k, jp;
     double one, tau, temp;
     int nptm;
     double zero, alpha, tempa, tempb, ztest;
@@ -70,7 +70,6 @@ static void update_(int *n, int *npt, double *bmat,
 
 /*     Apply the rotations that put zeros in the KNEW-th row of ZMAT. */
 
-    jl = 1;
     i__2 = nptm;
     for (j = 2; j <= i__2; ++j) {
 	if ((d__1 = zmat[*knew + j * zmat_dim1], fabs(d__1)) > ztest) {
@@ -1179,7 +1178,7 @@ static void trsbox_(int *n, int *npt, double *xpt,
     int isav;
     double temp, zero, xsav = 0.0, xsum, angbd = 0.0, dredg = 0.0, sredg = 0.0;
     int iterc;
-    double resid, delsq, ggsav = 0.0, tempa, tempb, ratio, sqstp, redmax, 
+    double resid, delsq, ggsav = 0.0, tempa, tempb, redmax,
 	    dredsq = 0.0, redsav, onemin, gredsq = 0.0, rednew;
     int itcsav = 0;
     double rdprev, rdnext = 0.0, stplen, stepsq;
@@ -1259,7 +1258,6 @@ static void trsbox_(int *n, int *npt, double *xpt,
 
     iterc = 0;
     nact = 0;
-    sqstp = zero;
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	xbdi[i__] = zero;
@@ -1512,7 +1510,6 @@ L120:
 		xbdi[i__] = one;
 		goto L100;
 	    }
-	    ratio = one;
 /* Computing 2nd power */
 	    d__1 = d__[i__];
 /* Computing 2nd power */

--- a/src/algs/bobyqa/bobyqa.c
+++ b/src/algs/bobyqa/bobyqa.c
@@ -1726,7 +1726,7 @@ static nlopt_result prelim_(int *n, int *npt, double *x,
     int i__, j, k, ih, np, nfm;
     double one;
     int nfx, ipt = 0, jpt = 0;
-    /* fbeg will be initialized below, init here to avoid maybe-uninitilaized warning */
+    /* fbeg will be initialized below, init here to avoid maybe-uninitialized warning */
     double two, fbeg = 0.0, diff, half, temp, zero, recip, stepa = 0.0, stepb = 0.0;
     int itemp;
     double rhosq;

--- a/src/algs/bobyqa/bobyqa.c
+++ b/src/algs/bobyqa/bobyqa.c
@@ -1726,7 +1726,8 @@ static nlopt_result prelim_(int *n, int *npt, double *x,
     int i__, j, k, ih, np, nfm;
     double one;
     int nfx, ipt = 0, jpt = 0;
-    double two, fbeg, diff, half, temp, zero, recip, stepa = 0.0, stepb = 0.0;
+    /* fbeg will be initialized below, init here to avoid maybe-uninitilaized warning */
+    double two, fbeg = 0.0, diff, half, temp, zero, recip, stepa = 0.0, stepb = 0.0;
     int itemp;
     double rhosq;
 

--- a/src/algs/cdirect/hybrid.c
+++ b/src/algs/cdirect/hybrid.c
@@ -88,7 +88,7 @@ static nlopt_result optimize_rect(double *r, params *p)
 	  lb[i] = c[i] - 0.5 * w[i];
 	  ub[i] = c[i] + 0.5 * w[i];
      }
-     ret = nlopt_minimize(p->local_alg, n, fcount, p, 
+     ret = internal_nlopt_minimize(p->local_alg, n, fcount, p,
 			  lb, ub, x, &minf,
 			  stop->minf_max, stop->ftol_rel, stop->ftol_abs,
 			  stop->xtol_rel, stop->xtol_abs,

--- a/src/algs/cobyla/cobyla.c
+++ b/src/algs/cobyla/cobyla.c
@@ -30,10 +30,13 @@
  * 
  * The original source code can be found at :
  * http://plato.la.asu.edu/topics/problems/nlores.html
+ *
+ * Original RCS id
+ * static char const rcsid[] =
+ *  "	@(#) $Jeannot: cobyla.c,v 1.11 2004/04/18 09:51:36 js Exp $";
+ *
  */
 
-static char const rcsid[] =
-  "@(#) $Jeannot: cobyla.c,v 1.11 2004/04/18 09:51:36 js Exp $";
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -1259,7 +1262,7 @@ static nlopt_result trstlp(int *n, int *m, double *a,
   double spabs;
   double temp, step;
   int icount;
-  int iout, i__, j, k;
+  int i__, j, k;
   int isave;
   int kk;
   int kl, kp, kw;
@@ -1476,10 +1479,8 @@ L130:
     temp = zdotv / zdota[k];
     if (temp > 0. && iact[k] <= *m) {
       tempa = vmultc[k] / temp;
-      if (ratio < 0. || tempa < ratio) {
+      if (ratio < 0. || tempa < ratio)
         ratio = tempa;
-        iout = k;
-      }
     }
     if (k >= 2) {
       kw = iact[k];

--- a/src/algs/direct/DIRect.c
+++ b/src/algs/direct/DIRect.c
@@ -78,7 +78,6 @@
     integer mdeep, *point = 0, start;
     integer *anchor = 0, *length = 0	/* was [90000][64] */, *arrayi = 0;
     doublereal *levels = 0, *thirds = 0;
-    integer writed;
     doublereal epsfix;
     integer oldpos, minpos, maxpos, tstart, actdeep, ifreeold, oldmaxf;
     integer numfunc, version;
@@ -325,7 +324,6 @@
     --x;
 
     /* Function Body */
-    writed = 0;
     jones = *algmethod;
 /* +-----------------------------------------------------------------------+ */
 /* | Save the upper and lower bounds.                                      | */

--- a/src/algs/direct/DIRserial.c
+++ b/src/algs/direct/DIRserial.c
@@ -22,6 +22,9 @@
 	const integer *maxdeep, integer *oops, doublereal *fmax, integer *
 	ifeasiblef, integer *iinfesiblef, void *fcn_data, int *force_stop)
 {
+    (void) logfile; (void) free; (void) maxfunc; (void) maxdeep; (void) oops;
+    (void) delta; (void) sample;
+
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
     doublereal d__1;

--- a/src/algs/direct/DIRsubrout.c
+++ b/src/algs/direct/DIRsubrout.c
@@ -33,6 +33,8 @@ static integer c__0 = 0;
 integer direct_dirgetlevel_(integer *pos, integer *length, integer *maxfunc, integer 
 	*n, integer jones)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, ret_val, i__1;
 
@@ -273,6 +275,8 @@ L40:
 	maxpos, integer *point, doublereal *f, const integer *maxdeep, integer *
 	maxfunc, const integer *maxdiv, integer *ierror)
 {
+    (void)  maxdeep; (void) maxfunc;
+
     /* System generated locals */
     integer s_dim1, s_offset, i__1;
 
@@ -344,6 +348,8 @@ L40:
 integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc, 
 	integer *n)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1, i__2, i__3;
 
@@ -370,6 +376,8 @@ integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc,
 static integer isinbox_(doublereal *x, doublereal *a, doublereal *b, integer *n, 
 	integer *lmaxdim)
 {
+    (void) lmaxdim;
+
     /* System generated locals */
     integer ret_val, i__1;
 
@@ -409,6 +417,8 @@ L1010:
 	maxfunc, integer *maxdim, const integer *maxdeep, FILE *logfile,
 					    integer jones)
 {
+    (void) maxdim; (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -502,7 +512,7 @@ L20:
 /* L30: */
 	    }
 L40:
-	    pos = pos;
+	    ;
 	}
     }
 } /* dirresortlist_ */
@@ -521,6 +531,8 @@ L40:
 	integer *maxfunc, const integer *maxdeep, integer *maxdim, integer *n, 
 	FILE *logfile, doublereal *fmax, integer jones)
 {
+    (void) freeold;
+
     /* System generated locals */
     integer c_dim1, c_offset, length_dim1, length_offset, i__1, i__2, i__3;
     doublereal d__1, d__2;
@@ -698,6 +710,8 @@ L40:
 	maxfunc, const integer *maxdeep, integer *n, integer *samp,
 					    integer jones)
 {
+    (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -865,6 +879,8 @@ L50:
 	 doublereal *minf, integer *minpos, doublereal *u, integer *n, 
 	integer *maxfunc, const integer *maxdeep, integer *oops)
 {
+    (void) minf; (void) minpos; (void) maxfunc; (void) maxdeep; (void) oops;
+
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
 
@@ -936,6 +952,8 @@ L50:
 	integer *list2, doublereal *w, integer *maxi, doublereal *f, integer *
 	maxfunc, const integer *maxdeep, integer *n)
 {
+    (void) maxfunc; (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, list2_dim1, list2_offset, i__1, i__2;
     doublereal d__1, d__2;
@@ -1082,6 +1100,8 @@ L50:
 /* Subroutine */ void direct_dirget_i__(integer *length, integer *pos, integer *
 	arrayi, integer *maxi, integer *n, integer *maxfunc)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -1154,7 +1174,6 @@ L50:
     integer i__, j;
     integer new__, help, oops;
     doublereal help2, delta;
-    doublereal costmin;
 
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
@@ -1191,7 +1210,6 @@ L50:
 
     /* Function Body */
     *minf = HUGE_VAL;
-    costmin = *minf;
 /* JG 09/15/00 If Jones way of characterising rectangles is used, */
 /*             initialise thirds to reflect this. */
     if (jones == 0) {
@@ -1256,7 +1274,6 @@ L50:
     }
 /* JG 09/25/00 Remove IF */
     *minf = f[3];
-    costmin = f[3];
     *minpos = 1;
     *actdeep = 2;
     point[1] = 0;
@@ -1438,6 +1455,8 @@ L50:
 	integer *ierror, doublereal *epsfix, integer *iepschange, doublereal *
 	volper, doublereal *sigmaper)
 {
+    (void) maxdeep; (void) ierror;
+
     /* System generated locals */
     integer i__1;
 
@@ -1557,6 +1576,8 @@ L50:
 	l, doublereal *u, integer *n, doublereal *minf, doublereal *fglobal, 
 	integer *numfunc, integer *ierror)
 {
+    (void) ierror;
+
     /* Local variables */
     integer i__;
 

--- a/src/algs/esch/esch.c
+++ b/src/algs/esch/esch.c
@@ -57,7 +57,8 @@ typedef struct IndividualStructure {
 } Individual;
 
 static int CompareIndividuals(void *unused, const void *a_, const void *b_) {
-     /* (void) unused; */
+     (void) unused;
+
      const Individual *a = (const Individual *) a_;
      const Individual *b = (const Individual *) b_;
      return a->fitness < b->fitness ? -1 : (a->fitness > b->fitness ? +1 : 0);

--- a/src/algs/luksan/plip.c
+++ b/src/algs/luksan/plip.c
@@ -120,6 +120,8 @@ static void plip_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+    (void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -136,10 +138,10 @@ static void plip_(int *nf, int *nb, double *x, int *
     int kbf, mec, mfg;
     double par;
     int mes, kit;
-    double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3, met3;
+    double alf1, alf2, eta9, par1, par2;
+    int met3;
     double eps8, eps9;
-    int meta, mred, nred, iold;
+    int mred, nred, iold;
     double maxf, dmax__;
     int xstop = 0;
     int inew;
@@ -196,14 +198,9 @@ static void plip_(int *nf, int *nb, double *x, int *
     ires1 = 999;
     ires2 = 0;
     mred = 10;
-    meta = 1;
     met3 = 4;
     mec = 4;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
-    eta0 = 1e-15;
     eta9 = 1e120;
     eps8 = 1.;
     eps9 = 1e-8;

--- a/src/algs/luksan/plis.c
+++ b/src/algs/luksan/plis.c
@@ -113,6 +113,8 @@ static void plis_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+    (void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -127,8 +129,7 @@ static void plis_(int *nf, int *nb, double *x, int *
     double fo, fp, po, pp, ro, rp;
     int kbf, mfg;
     int mes, kit;
-    double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3;
+    double alf1, alf2, eta9, par1, par2;
     double eps8, eps9;
     int mred, iold, nred;
     double maxf, dmax__;
@@ -185,10 +186,6 @@ static void plis_(int *nf, int *nb, double *x, int *
     ires2 = 0;
     mred = 10;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
-    eta0 = 1e-15;
     eta9 = 1e120;
     eps8 = 1.;
     eps9 = 1e-8;

--- a/src/algs/luksan/pnet.c
+++ b/src/algs/luksan/pnet.c
@@ -137,6 +137,8 @@ static void pnet_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+	(void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -156,7 +158,6 @@ static void pnet_(int *nf, int *nb, double *x, int *
     double rho, eps;
     int mmx;
     double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3;
     double rho1, rho2, eps8, eps9;
     int mred, iold, nred;
     double maxf, dmax__;
@@ -218,9 +219,6 @@ static void pnet_(int *nf, int *nb, double *x, int *
     ires2 = 0;
     mred = 10;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
     eps = .8;
     eta0 = 1e-15;
     eta9 = 1e120;

--- a/src/algs/luksan/pssubs.c
+++ b/src/algs/luksan/pssubs.c
@@ -518,13 +518,15 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
 	double *r__, double *po, double *sig, int *iterh, 
 	int *met3)
 {
+    (void) r__; (void) po;
+
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
     /* Builtin functions */
 
     /* Local variables */
-    double a, b, c__, aa, bb, ah, den, par, pom;
+    double a, b, aa, bb, ah, den, par, pom;
 
     /* Parameter adjustments */
     --go;
@@ -545,7 +547,6 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
     ah = luksan_mxvdot__(n, &go[1], &go[1]);
     aa = luksan_mxvdot__(m, &gr[1], &gr[1]);
     a = aa + ah * *sig;
-    c__ = -(*r__) * *po;
 
 /*     DETERMINATION OF THE PARAMETER SIG (SHIFT) */
 
@@ -647,13 +648,15 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
 	double *sig, int *iterh, int *met2, int *met3, 
 	int *met5)
 {
+    (void) po;
+
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
     /* Builtin functions */
 
     /* Local variables */
-    double a, b, c__, aa, bb, cc, ah, den, par, pom, zet;
+    double a, b, aa, bb, cc, ah, den, par, pom, zet;
 
     /* Parameter adjustments */
     --go;
@@ -689,7 +692,6 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
     bb = luksan_mxvdot__(m, &gr[1], &xr[1]);
     cc = luksan_mxvdot__(m, &xr[1], &xr[1]);
     a = aa + ah * *sig;
-    c__ = -(*r__) * *po;
 
 /*     DETERMINATION OF THE PARAMETER SIG (SHIFT) */
 

--- a/src/algs/neldermead/sbplx.c
+++ b/src/algs/neldermead/sbplx.c
@@ -75,7 +75,6 @@ nlopt_result sbplx_minimize(int n, nlopt_func f, void *f_data,
      int *p; /* permuted indices of x sorted by decreasing magnitude |dx| */
      int i;
      subspace_data sd;
-     double fprev;
 
      *minf = f(n, x, NULL, f_data);
      ++ *(stop->nevals_p);
@@ -111,7 +110,6 @@ nlopt_result sbplx_minimize(int n, nlopt_func f, void *f_data,
 	  double fdiff, fdiff_max = 0;
 
 	  memcpy(xprev, x, n * sizeof(double));
-	  fprev = *minf;
 
 	  /* sort indices into the progress vector dx by decreasing
 	     order of magnitude |dx| */

--- a/src/algs/newuoa/newuoa.c
+++ b/src/algs/newuoa/newuoa.c
@@ -181,7 +181,7 @@ static nlopt_result trsapp_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-7 * *delta; /* absolute x tolerance */
 	 }
 	 memset(&step[1], 0, sizeof(double) * *n);
-	 ret = nlopt_minimize_constrained(NLOPT_LD_MMA, *n, quad_model, &qmd,
+	 ret = internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, quad_model, &qmd,
 				    1, rho_constraint, delta, sizeof(double),
 				    slb, sub, &step[1], &minf, -HUGE_VAL,
 				    0., 0., 0., xtol, 1000, 0.);
@@ -1238,7 +1238,7 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-5 * *delta;
 	 }
 	 ld.flipsign = lag(*n, &d__[1], 0, &ld) > 0; /* maximize if > 0 */
-	 return nlopt_minimize_constrained(NLOPT_LD_MMA, *n, lag, &ld,
+	 return internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, lag, &ld,
 				    1, rho_constraint, delta, sizeof(double),
 				    dlb, dub, &d__[1], &minf, -HUGE_VAL,
 				    0., 0., 0., xtol, 1000, 0.);

--- a/src/algs/newuoa/newuoa.c
+++ b/src/algs/newuoa/newuoa.c
@@ -1070,7 +1070,8 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
     int nptm;
     double zero, angle, scale, denom;
     int iterc, isave;
-    double delsq, tempa, tempb = 0.0, twopi, taubeg, tauold, taumax;
+    /* Note: tempa is initialized below, initialization here is only used to avoid 'maybe-uninitialized' warning */
+    double delsq, tempa = 0.0, tempb = 0.0, twopi, taubeg, tauold, taumax;
 
 
 /* N is the number of variables. */

--- a/src/algs/slsqp/slsqp.c
+++ b/src/algs/slsqp/slsqp.c
@@ -2497,9 +2497,11 @@ nlopt_result nlopt_slsqp(unsigned n, nlopt_func f, void *f_data,
 	  switch (mode) {
 	  case -1:  /* objective & gradient evaluation */
 	      if (prev_mode == -2 && !want_grad) break; /* just evaluated this point */
+	      /* fall through */
 	  case -2:
 	      eval_f_and_grad:
 	      want_grad = 1;
+	      /* fall through */
 	  case 1:{ /* don't need grad unless we don't have it yet */
 	      double *newgrad = 0;
 	      double *newcgrad = 0;

--- a/src/algs/stogo/global.h
+++ b/src/algs/stogo/global.h
@@ -49,6 +49,7 @@ public:
        switch (which) {
 	   case OBJECTIVE_AND_GRADIENT:
 		Gradient(xy, grad);
+		return Objective(xy);
 	   case OBJECTIVE_ONLY:
 		return Objective(xy);
 	   case GRADIENT_ONLY:

--- a/src/api/deprecated.c
+++ b/src/api/deprecated.c
@@ -162,6 +162,11 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_econstrained(nlopt_algorithm algorithm
     return ret;
 }
 
+/* don't emit inner deprecated warnings */
+#ifdef COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 nlopt_result NLOPT_STDCALL nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, const double *lb, const double *ub,   /* bounds */
                                                       double *x,        /* in: initial guess, out: minimizer */
                                                       double *minf,     /* out: minimum */
@@ -171,7 +176,27 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_constrained(nlopt_algorithm algorithm,
                                        m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
 }
 
+/* used internally, without deprecation warning */
+nlopt_result NLOPT_STDCALL internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, const double *lb, const double *ub,   /* bounds */
+                                                      double *x,        /* in: initial guess, out: minimizer */
+                                                      double *minf,     /* out: minimum */
+                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
+{
+    return nlopt_minimize_econstrained(algorithm, n, f, f_data,
+                                       m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
+}
+
+
 nlopt_result NLOPT_STDCALL nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
+                                          double *x,    /* in: initial guess, out: minimizer */
+                                          double *minf, /* out: minimum */
+                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
+{
+    return nlopt_minimize_constrained(algorithm, n, f, f_data, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, maxeval, maxtime);
+}
+
+/* used internally, without deprecation warning */
+nlopt_result NLOPT_STDCALL internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
                                           double *x,    /* in: initial guess, out: minimizer */
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)

--- a/src/api/deprecated.c
+++ b/src/api/deprecated.c
@@ -163,7 +163,7 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_econstrained(nlopt_algorithm algorithm
 }
 
 /* don't emit inner deprecated warnings */
-#ifdef COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/src/api/f77funcs.h
+++ b/src/api/f77funcs.h
@@ -19,7 +19,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
  */
-#ifdef COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 

--- a/src/api/f77funcs.h
+++ b/src/api/f77funcs.h
@@ -19,6 +19,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
  */
+#ifdef COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 /* Fortran API wrappers, using the F77 macro defined in f77api.c.
    This header file is #included one or more times from f77api.c

--- a/src/api/nlopt.h
+++ b/src/api/nlopt.h
@@ -288,6 +288,7 @@ NLOPT_EXTERN(void) nlopt_munge_data(nlopt_opt opt, nlopt_munge2 munge, void *dat
    for code that uses a deprecated function */
 #if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
 #  define NLOPT_DEPRECATED __attribute__((deprecated))
+#  define COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
 #else
 #  define NLOPT_DEPRECATED
 #endif
@@ -301,11 +302,25 @@ NLOPT_EXTERN(nlopt_result) nlopt_minimize(nlopt_algorithm algorithm, int n, nlop
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
 
+/* this is still used internally by a few algorithms, it's the same as nlopt_minimize, but without the deprecation */
+NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data,
+                                          const double *lb, const double *ub, /* bounds */
+                                          double *x,    /* in: initial guess, out: minimizer */
+                                          double *minf, /* out: minimum */
+                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
+
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
                                                       const double *lb, const double *ub,   /* bounds */
                                                       double *x,        /* in: initial guess, out: minimizer */
                                                       double *minf,     /* out: minimum */
                                                       double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
+
+/* this is still used internally by a few algorithms, it's the same as nlopt_minimize_constrained, but without the deprecation */
+NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
+                                                      const double *lb, const double *ub,   /* bounds */
+                                                      double *x,        /* in: initial guess, out: minimizer */
+                                                      double *minf,     /* out: minimum */
+                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
 
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_econstrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, int p, nlopt_func_old h, void *h_data, ptrdiff_t h_datum_size,
                                                        const double *lb, const double *ub,   /* bounds */

--- a/src/api/nlopt.h
+++ b/src/api/nlopt.h
@@ -288,7 +288,6 @@ NLOPT_EXTERN(void) nlopt_munge_data(nlopt_opt opt, nlopt_munge2 munge, void *dat
    for code that uses a deprecated function */
 #if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
 #  define NLOPT_DEPRECATED __attribute__((deprecated))
-#  define COMPILER_PROVIDES_DEPRECATED_ATTRIBUTE
 #else
 #  define NLOPT_DEPRECATED
 #endif


### PR DESCRIPTION
 - remove set but not used variables
 - (void) cast unused function arguments
 - create internal function duplicates for some actually
   deprecated functions, for the f77 files disable
   the deprecation warning completely.

I'm not sure if the changes in CMakeLists.txt are appropriate as I'm not much of a cmaker, please advise.

Closes #226.