### PR TITLE
Add -Wall and -Wextra, fix lots of warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
         - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..

--- a/src/algs/ags/local_optimizer.cc
+++ b/src/algs/ags/local_optimizer.cc
@@ -32,7 +32,8 @@ Trial HookeJeevesOptimizer::Optimize(std::shared_ptr<IGOProblem<double>> problem
 
   int k = 0, i=0;
   bool needRestart = true;
-  double currentFValue, nextFValue;
+  /* currentFvalue will be initialized below, init here to avoid maybe-uninitialized warning */
+  double currentFValue = 0.0, nextFValue;
 
   while (i < MAX_LOCAL_ITERATIONS_NUMBER)	{
     i++;

--- a/src/algs/ags/solver.cc
+++ b/src/algs/ags/solver.cc
@@ -58,7 +58,7 @@ namespace
           right[i] = mRightBound[i];
         }
       }
-      int GetOptimumPoint(double* y) const {return 0;}
+      int GetOptimumPoint(double*) const {return 0;}
       double GetOptimumValue() const {return 0;}
     };
 }

--- a/src/algs/bobyqa/bobyqa.c
+++ b/src/algs/bobyqa/bobyqa.c
@@ -24,7 +24,7 @@ static void update_(int *n, int *npt, double *bmat,
     double d__1, d__2, d__3;
 
     /* Local variables */
-    int i__, j, k, jl, jp;
+    int i__, j, k, jp;
     double one, tau, temp;
     int nptm;
     double zero, alpha, tempa, tempb, ztest;
@@ -70,7 +70,6 @@ static void update_(int *n, int *npt, double *bmat,
 
 /*     Apply the rotations that put zeros in the KNEW-th row of ZMAT. */
 
-    jl = 1;
     i__2 = nptm;
     for (j = 2; j <= i__2; ++j) {
 	if ((d__1 = zmat[*knew + j * zmat_dim1], fabs(d__1)) > ztest) {
@@ -1179,7 +1178,7 @@ static void trsbox_(int *n, int *npt, double *xpt,
     int isav;
     double temp, zero, xsav = 0.0, xsum, angbd = 0.0, dredg = 0.0, sredg = 0.0;
     int iterc;
-    double resid, delsq, ggsav = 0.0, tempa, tempb, ratio, sqstp, redmax, 
+    double resid, delsq, ggsav = 0.0, tempa, tempb, redmax,
 	    dredsq = 0.0, redsav, onemin, gredsq = 0.0, rednew;
     int itcsav = 0;
     double rdprev, rdnext = 0.0, stplen, stepsq;
@@ -1259,7 +1258,6 @@ static void trsbox_(int *n, int *npt, double *xpt,
 
     iterc = 0;
     nact = 0;
-    sqstp = zero;
     i__1 = *n;
     for (i__ = 1; i__ <= i__1; ++i__) {
 	xbdi[i__] = zero;
@@ -1512,7 +1510,6 @@ L120:
 		xbdi[i__] = one;
 		goto L100;
 	    }
-	    ratio = one;
 /* Computing 2nd power */
 	    d__1 = d__[i__];
 /* Computing 2nd power */
@@ -1729,7 +1726,8 @@ static nlopt_result prelim_(int *n, int *npt, double *x,
     int i__, j, k, ih, np, nfm;
     double one;
     int nfx, ipt = 0, jpt = 0;
-    double two, fbeg, diff, half, temp, zero, recip, stepa = 0.0, stepb = 0.0;
+    /* fbeg will be initialized below, init here to avoid maybe-uninitialized warning */
+    double two, fbeg = 0.0, diff, half, temp, zero, recip, stepa = 0.0, stepb = 0.0;
     int itemp;
     double rhosq;
 

--- a/src/algs/cdirect/hybrid.c
+++ b/src/algs/cdirect/hybrid.c
@@ -7,17 +7,17 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include <math.h>
@@ -32,7 +32,7 @@
 /* Hybrid algorithm, inspired by DIRECT, that uses another local
  * optimization algorithm within each rectangle, and then looks
  * in the largest remaining rectangle (breaking ties by minimum
- * function value and then by age. 
+ * function value and then by age.
  *
  * Each hyperrect is represented by an array of length 3*n+3 consisting
  * of (d, -f, -a, x, c, w), where d=diameter, f=f(x), a=age, x=local optimum
@@ -49,9 +49,9 @@ typedef struct {
      rb_tree rtree; /* red-black tree of rects, sorted by (d,-f,-a) */
      int age; /* age for next new rect */
      double *work; /* workspace of length >= 2*n */
-     
-     nlopt_algorithm local_alg; /* local search algorithm */
-     int local_maxeval; /* max # local iterations (0 if unlimited) */
+
+     nlopt_opt local_opt;  /* local search algorithm */
+     int local_maxeval;
 
      int randomized_div; /* 1 to use randomized division algorithm */
 } params;
@@ -62,7 +62,7 @@ typedef struct {
 
 /************************************************************************/
 
-static double fcount(int n, const double *x, double *grad, void *p_)
+static double fcount(unsigned n, const double *x, double *grad, void *p_)
 {
      params *p = (params *) p_;
      ++ *(p->stop->nevals_p);
@@ -78,7 +78,8 @@ static nlopt_result optimize_rect(double *r, params *p)
      double minf;
      nlopt_stopping *stop = p->stop;
      nlopt_result ret;
-     
+     nlopt_opt opt;
+
      if (stop->maxeval > 0 &&
 	 *(stop->nevals_p) >= stop->maxeval) return NLOPT_MAXEVAL_REACHED;
      if (stop->maxtime > 0 &&
@@ -88,15 +89,18 @@ static nlopt_result optimize_rect(double *r, params *p)
 	  lb[i] = c[i] - 0.5 * w[i];
 	  ub[i] = c[i] + 0.5 * w[i];
      }
-     ret = internal_nlopt_minimize(p->local_alg, n, fcount, p,
-			  lb, ub, x, &minf,
-			  stop->minf_max, stop->ftol_rel, stop->ftol_abs,
-			  stop->xtol_rel, stop->xtol_abs,
-			  p->local_maxeval > 0 ?
-			  MIN(p->local_maxeval, 
-			      stop->maxeval - *(stop->nevals_p))
-			  : stop->maxeval - *(stop->nevals_p),
-			  stop->maxtime - (t - stop->start));
+     ret = nlopt_set_lower_bounds(p->local_opt, lb);
+     if (ret != NLOPT_SUCCESS) return ret;
+     ret = nlopt_set_upper_bounds(p->local_opt, ub);
+     if (ret != NLOPT_SUCCESS) return ret;
+     if (p->local_maxeval > 0) {
+          ret = nlopt_set_maxeval(p->local_opt,
+               MIN(p->local_maxeval, stop->maxeval - *(stop->nevals_p)));
+          if (ret != NLOPT_SUCCESS) return ret;
+     }
+     ret = nlopt_set_maxtime(p->local_opt, stop->maxtime - (t - stop->start));
+     if (ret != NLOPT_SUCCESS) return ret;
+     ret = nlopt_optimize(p->local_opt, x, &minf);
      r[1] = -minf;
      if (ret > 0) {
 	  if (minf < p->minf) {
@@ -248,14 +252,13 @@ nlopt_result cdirect_hybrid_unscaled(int n, nlopt_func f, void *f_data,
      p.xmin = x;
      p.age = 0;
      p.work = 0;
-     p.local_alg = local_alg;
-     p.local_maxeval = local_maxeval;
      p.randomized_div = randomized_div;
+     p.local_opt = 0;
 
      rb_tree_init(&p.rtree, cdirect_hyperrect_compare);
      p.work = (double *) malloc(sizeof(double) * (2*n));
      if (!p.work) goto done;
-     
+
      if (!(rnew = (double *) malloc(sizeof(double) * p.L))) goto done;
      for (i = 0; i < n; ++i) {
           rnew[3+i] = rnew[3+n+i] = 0.5 * (lb[i] + ub[i]);
@@ -263,6 +266,28 @@ nlopt_result cdirect_hybrid_unscaled(int n, nlopt_func f, void *f_data,
      }
      rnew[0] = longest(n, rnew+2*n);
      rnew[2] = p.age--;
+
+     p.local_opt = nlopt_create(local_alg, n);
+     if (!p.local_opt) {
+          ret = NLOPT_INVALID_ARGS;
+          goto done;
+     }
+     p.local_maxeval = local_maxeval;
+     ret = nlopt_set_stopval(p.local_opt, stop->minf_max);
+     if (ret != NLOPT_SUCCESS) goto done;
+     ret = nlopt_set_ftol_rel(p.local_opt, stop->ftol_rel);
+     if (ret != NLOPT_SUCCESS) goto done;
+     ret = nlopt_set_ftol_abs(p.local_opt, stop->ftol_abs);
+     if (ret != NLOPT_SUCCESS) goto done;
+     ret = nlopt_set_xtol_rel(p.local_opt, stop->xtol_rel);
+     if (ret != NLOPT_SUCCESS) goto done;
+     if (stop->xtol_abs) {
+          ret = nlopt_set_xtol_abs(p.local_opt, stop->xtol_abs);
+          if (ret != NLOPT_SUCCESS) goto done;
+     }
+     ret = nlopt_set_min_objective(p.local_opt, fcount, &p);
+     if (ret != NLOPT_SUCCESS) goto done;
+
      ret = optimize_rect(rnew, &p);
      if (ret != NLOPT_SUCCESS) { free(rnew); goto done; }
      if (!rb_tree_insert(&p.rtree, rnew)) { free(rnew); goto done; }
@@ -274,7 +299,8 @@ nlopt_result cdirect_hybrid_unscaled(int n, nlopt_func f, void *f_data,
  done:
      rb_tree_destroy_with_keys(&p.rtree);
      free(p.work);
-	      
+     nlopt_destroy(p.local_opt);
+
      *minf = p.minf;
      return ret;
 }
@@ -297,7 +323,7 @@ nlopt_result cdirect_hybrid(int n, nlopt_func f, void *f_data,
      d.f = f; d.f_data = f_data; d.lb = lb; d.ub = ub;
      d.x = (double *) malloc(sizeof(double) * n*4);
      if (!d.x) return NLOPT_OUT_OF_MEMORY;
-     
+
      for (i = 0; i < n; ++i) {
 	  x[i] = (x[i] - lb[i]) / (ub[i] - lb[i]);
 	  d.x[n+i] = 0;
@@ -306,7 +332,7 @@ nlopt_result cdirect_hybrid(int n, nlopt_func f, void *f_data,
      }
      xtol_abs_save = stop->xtol_abs;
      stop->xtol_abs = d.x + 3*n;
-     ret = cdirect_hybrid_unscaled(n, cdirect_uf, &d, d.x+n, d.x+2*n, 
+     ret = cdirect_hybrid_unscaled(n, cdirect_uf, &d, d.x+n, d.x+2*n,
 				   x, minf, stop, local_alg, local_maxeval,
 				   randomized_div);
      stop->xtol_abs = xtol_abs_save;

--- a/src/algs/cdirect/hybrid.c
+++ b/src/algs/cdirect/hybrid.c
@@ -88,7 +88,7 @@ static nlopt_result optimize_rect(double *r, params *p)
 	  lb[i] = c[i] - 0.5 * w[i];
 	  ub[i] = c[i] + 0.5 * w[i];
      }
-     ret = nlopt_minimize(p->local_alg, n, fcount, p, 
+     ret = internal_nlopt_minimize(p->local_alg, n, fcount, p,
 			  lb, ub, x, &minf,
 			  stop->minf_max, stop->ftol_rel, stop->ftol_abs,
 			  stop->xtol_rel, stop->xtol_abs,

--- a/src/algs/cobyla/cobyla.c
+++ b/src/algs/cobyla/cobyla.c
@@ -30,10 +30,13 @@
  * 
  * The original source code can be found at :
  * http://plato.la.asu.edu/topics/problems/nlores.html
+ *
+ * Original RCS id
+ * static char const rcsid[] =
+ *  "	@(#) $Jeannot: cobyla.c,v 1.11 2004/04/18 09:51:36 js Exp $";
+ *
  */
 
-static char const rcsid[] =
-  "@(#) $Jeannot: cobyla.c,v 1.11 2004/04/18 09:51:36 js Exp $";
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -1259,7 +1262,7 @@ static nlopt_result trstlp(int *n, int *m, double *a,
   double spabs;
   double temp, step;
   int icount;
-  int iout, i__, j, k;
+  int i__, j, k;
   int isave;
   int kk;
   int kl, kp, kw;
@@ -1476,10 +1479,8 @@ L130:
     temp = zdotv / zdota[k];
     if (temp > 0. && iact[k] <= *m) {
       tempa = vmultc[k] / temp;
-      if (ratio < 0. || tempa < ratio) {
+      if (ratio < 0. || tempa < ratio)
         ratio = tempa;
-        iout = k;
-      }
     }
     if (k >= 2) {
       kw = iact[k];

--- a/src/algs/direct/DIRect.c
+++ b/src/algs/direct/DIRect.c
@@ -78,7 +78,6 @@
     integer mdeep, *point = 0, start;
     integer *anchor = 0, *length = 0	/* was [90000][64] */, *arrayi = 0;
     doublereal *levels = 0, *thirds = 0;
-    integer writed;
     doublereal epsfix;
     integer oldpos, minpos, maxpos, tstart, actdeep, ifreeold, oldmaxf;
     integer numfunc, version;
@@ -325,7 +324,6 @@
     --x;
 
     /* Function Body */
-    writed = 0;
     jones = *algmethod;
 /* +-----------------------------------------------------------------------+ */
 /* | Save the upper and lower bounds.                                      | */

--- a/src/algs/direct/DIRserial.c
+++ b/src/algs/direct/DIRserial.c
@@ -22,6 +22,9 @@
 	const integer *maxdeep, integer *oops, doublereal *fmax, integer *
 	ifeasiblef, integer *iinfesiblef, void *fcn_data, int *force_stop)
 {
+    (void) logfile; (void) free; (void) maxfunc; (void) maxdeep; (void) oops;
+    (void) delta; (void) sample;
+
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
     doublereal d__1;

--- a/src/algs/direct/DIRsubrout.c
+++ b/src/algs/direct/DIRsubrout.c
@@ -33,6 +33,8 @@ static integer c__0 = 0;
 integer direct_dirgetlevel_(integer *pos, integer *length, integer *maxfunc, integer 
 	*n, integer jones)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, ret_val, i__1;
 
@@ -273,6 +275,8 @@ L40:
 	maxpos, integer *point, doublereal *f, const integer *maxdeep, integer *
 	maxfunc, const integer *maxdiv, integer *ierror)
 {
+    (void)  maxdeep; (void) maxfunc;
+
     /* System generated locals */
     integer s_dim1, s_offset, i__1;
 
@@ -344,6 +348,8 @@ L40:
 integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc, 
 	integer *n)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1, i__2, i__3;
 
@@ -370,6 +376,8 @@ integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc,
 static integer isinbox_(doublereal *x, doublereal *a, doublereal *b, integer *n, 
 	integer *lmaxdim)
 {
+    (void) lmaxdim;
+
     /* System generated locals */
     integer ret_val, i__1;
 
@@ -409,6 +417,8 @@ L1010:
 	maxfunc, integer *maxdim, const integer *maxdeep, FILE *logfile,
 					    integer jones)
 {
+    (void) maxdim; (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -502,7 +512,7 @@ L20:
 /* L30: */
 	    }
 L40:
-	    pos = pos;
+	    ;
 	}
     }
 } /* dirresortlist_ */
@@ -521,6 +531,8 @@ L40:
 	integer *maxfunc, const integer *maxdeep, integer *maxdim, integer *n, 
 	FILE *logfile, doublereal *fmax, integer jones)
 {
+    (void) freeold;
+
     /* System generated locals */
     integer c_dim1, c_offset, length_dim1, length_offset, i__1, i__2, i__3;
     doublereal d__1, d__2;
@@ -698,6 +710,8 @@ L40:
 	maxfunc, const integer *maxdeep, integer *n, integer *samp,
 					    integer jones)
 {
+    (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -865,6 +879,8 @@ L50:
 	 doublereal *minf, integer *minpos, doublereal *u, integer *n, 
 	integer *maxfunc, const integer *maxdeep, integer *oops)
 {
+    (void) minf; (void) minpos; (void) maxfunc; (void) maxdeep; (void) oops;
+
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
 
@@ -936,6 +952,8 @@ L50:
 	integer *list2, doublereal *w, integer *maxi, doublereal *f, integer *
 	maxfunc, const integer *maxdeep, integer *n)
 {
+    (void) maxfunc; (void) maxdeep;
+
     /* System generated locals */
     integer length_dim1, length_offset, list2_dim1, list2_offset, i__1, i__2;
     doublereal d__1, d__2;
@@ -1082,6 +1100,8 @@ L50:
 /* Subroutine */ void direct_dirget_i__(integer *length, integer *pos, integer *
 	arrayi, integer *maxi, integer *n, integer *maxfunc)
 {
+    (void) maxfunc;
+
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -1154,7 +1174,6 @@ L50:
     integer i__, j;
     integer new__, help, oops;
     doublereal help2, delta;
-    doublereal costmin;
 
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
@@ -1191,7 +1210,6 @@ L50:
 
     /* Function Body */
     *minf = HUGE_VAL;
-    costmin = *minf;
 /* JG 09/15/00 If Jones way of characterising rectangles is used, */
 /*             initialise thirds to reflect this. */
     if (jones == 0) {
@@ -1256,7 +1274,6 @@ L50:
     }
 /* JG 09/25/00 Remove IF */
     *minf = f[3];
-    costmin = f[3];
     *minpos = 1;
     *actdeep = 2;
     point[1] = 0;
@@ -1438,6 +1455,8 @@ L50:
 	integer *ierror, doublereal *epsfix, integer *iepschange, doublereal *
 	volper, doublereal *sigmaper)
 {
+    (void) maxdeep; (void) ierror;
+
     /* System generated locals */
     integer i__1;
 
@@ -1557,6 +1576,8 @@ L50:
 	l, doublereal *u, integer *n, doublereal *minf, doublereal *fglobal, 
 	integer *numfunc, integer *ierror)
 {
+    (void) ierror;
+
     /* Local variables */
     integer i__;
 

--- a/src/algs/esch/esch.c
+++ b/src/algs/esch/esch.c
@@ -57,7 +57,8 @@ typedef struct IndividualStructure {
 } Individual;
 
 static int CompareIndividuals(void *unused, const void *a_, const void *b_) {
-     /* (void) unused; */
+     (void) unused;
+
      const Individual *a = (const Individual *) a_;
      const Individual *b = (const Individual *) b_;
      return a->fitness < b->fitness ? -1 : (a->fitness > b->fitness ? +1 : 0);

--- a/src/algs/luksan/plip.c
+++ b/src/algs/luksan/plip.c
@@ -120,6 +120,8 @@ static void plip_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+    (void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -136,10 +138,10 @@ static void plip_(int *nf, int *nb, double *x, int *
     int kbf, mec, mfg;
     double par;
     int mes, kit;
-    double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3, met3;
+    double alf1, alf2, eta9, par1, par2;
+    int met3;
     double eps8, eps9;
-    int meta, mred, nred, iold;
+    int mred, nred, iold;
     double maxf, dmax__;
     int xstop = 0;
     int inew;
@@ -196,14 +198,9 @@ static void plip_(int *nf, int *nb, double *x, int *
     ires1 = 999;
     ires2 = 0;
     mred = 10;
-    meta = 1;
     met3 = 4;
     mec = 4;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
-    eta0 = 1e-15;
     eta9 = 1e120;
     eps8 = 1.;
     eps9 = 1e-8;

--- a/src/algs/luksan/plis.c
+++ b/src/algs/luksan/plis.c
@@ -113,6 +113,8 @@ static void plis_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+    (void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -127,8 +129,7 @@ static void plis_(int *nf, int *nb, double *x, int *
     double fo, fp, po, pp, ro, rp;
     int kbf, mfg;
     int mes, kit;
-    double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3;
+    double alf1, alf2, eta9, par1, par2;
     double eps8, eps9;
     int mred, iold, nred;
     double maxf, dmax__;
@@ -185,10 +186,6 @@ static void plis_(int *nf, int *nb, double *x, int *
     ires2 = 0;
     mred = 10;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
-    eta0 = 1e-15;
     eta9 = 1e120;
     eps8 = 1.;
     eps9 = 1e-8;

--- a/src/algs/luksan/pnet.c
+++ b/src/algs/luksan/pnet.c
@@ -137,6 +137,8 @@ static void pnet_(int *nf, int *nb, double *x, int *
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
+	(void) tolb;
+
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -156,7 +158,6 @@ static void pnet_(int *nf, int *nb, double *x, int *
     double rho, eps;
     int mmx;
     double alf1, alf2, eta0, eta9, par1, par2;
-    int mes1, mes2, mes3;
     double rho1, rho2, eps8, eps9;
     int mred, iold, nred;
     double maxf, dmax__;
@@ -218,9 +219,6 @@ static void pnet_(int *nf, int *nb, double *x, int *
     ires2 = 0;
     mred = 10;
     mes = 4;
-    mes1 = 2;
-    mes2 = 2;
-    mes3 = 2;
     eps = .8;
     eta0 = 1e-15;
     eta9 = 1e120;

--- a/src/algs/luksan/pssubs.c
+++ b/src/algs/luksan/pssubs.c
@@ -518,13 +518,15 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
 	double *r__, double *po, double *sig, int *iterh, 
 	int *met3)
 {
+    (void) r__; (void) po;
+
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
     /* Builtin functions */
 
     /* Local variables */
-    double a, b, c__, aa, bb, ah, den, par, pom;
+    double a, b, aa, bb, ah, den, par, pom;
 
     /* Parameter adjustments */
     --go;
@@ -545,7 +547,6 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
     ah = luksan_mxvdot__(n, &go[1], &go[1]);
     aa = luksan_mxvdot__(m, &gr[1], &gr[1]);
     a = aa + ah * *sig;
-    c__ = -(*r__) * *po;
 
 /*     DETERMINATION OF THE PARAMETER SIG (SHIFT) */
 
@@ -647,13 +648,15 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
 	double *sig, int *iterh, int *met2, int *met3, 
 	int *met5)
 {
+    (void) po;
+
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
     /* Builtin functions */
 
     /* Local variables */
-    double a, b, c__, aa, bb, cc, ah, den, par, pom, zet;
+    double a, b, aa, bb, cc, ah, den, par, pom, zet;
 
     /* Parameter adjustments */
     --go;
@@ -689,7 +692,6 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
     bb = luksan_mxvdot__(m, &gr[1], &xr[1]);
     cc = luksan_mxvdot__(m, &xr[1], &xr[1]);
     a = aa + ah * *sig;
-    c__ = -(*r__) * *po;
 
 /*     DETERMINATION OF THE PARAMETER SIG (SHIFT) */
 

--- a/src/algs/neldermead/sbplx.c
+++ b/src/algs/neldermead/sbplx.c
@@ -75,7 +75,6 @@ nlopt_result sbplx_minimize(int n, nlopt_func f, void *f_data,
      int *p; /* permuted indices of x sorted by decreasing magnitude |dx| */
      int i;
      subspace_data sd;
-     double fprev;
 
      *minf = f(n, x, NULL, f_data);
      ++ *(stop->nevals_p);
@@ -111,7 +110,6 @@ nlopt_result sbplx_minimize(int n, nlopt_func f, void *f_data,
 	  double fdiff, fdiff_max = 0;
 
 	  memcpy(xprev, x, n * sizeof(double));
-	  fprev = *minf;
 
 	  /* sort indices into the progress vector dx by decreasing
 	     order of magnitude |dx| */

--- a/src/algs/newuoa/newuoa.c
+++ b/src/algs/newuoa/newuoa.c
@@ -8,17 +8,17 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 /* NEWUOA derivative-free optimization algorithm by M. J. D. Powell.
@@ -45,13 +45,13 @@ typedef struct {
      int iter;
 } quad_model_data;
 
-static double quad_model(int n, const double *x, double *grad, void *data)
+static double quad_model(unsigned n, const double *x, double *grad, void *data)
 {
      quad_model_data *d = (quad_model_data *) data;
      const double *xpt = d->xpt, *pq = d->pq, *hq = d->hq, *gq = d->gq, *xopt = d->xopt;
      double *hd = d->hd;
-     int npt = d->npt;
-     int i, j, k;
+     int npt = d->npt, k;
+     unsigned i, j;
      double val = 0;
 
      /* first, set hd to be Hessian matrix times x */
@@ -85,20 +85,20 @@ static double quad_model(int n, const double *x, double *grad, void *data)
 }
 
 /* constraint function to enforce |x|^2 <= rho*rho */
-static double rho_constraint(int n, const double *x, double *grad, void *data)
+static double rho_constraint(unsigned n, const double *x, double *grad, void *data)
 {
      double rho = *((double *) data);
      double val = - rho*rho;
-     int i;
+     unsigned i;
      for (i = 0; i < n; ++i)
 	  val += x[i] * x[i];
      if (grad) for (i = 0; i < n; ++i) grad[i] = 2*x[i];
      return val;
 }
 
-static nlopt_result trsapp_(int *n, int *npt, double *xopt, 
-	double *xpt, double *gq, double *hq, double *pq, 
-	double *delta, double *step, double *d__, double *g, 
+static nlopt_result trsapp_(int *n, int *npt, double *xopt,
+	double *xpt, double *gq, double *hq, double *pq,
+	double *delta, double *step, double *d__, double *g,
 	double *hd, double *hs, double *crvmin,
 		    const double *xbase, const double *lb, const double *ub)
 {
@@ -156,6 +156,7 @@ static nlopt_result trsapp_(int *n, int *npt, double *xopt,
     --hs;
 
     if (lb && ub) {
+	 nlopt_opt opt;
 	 double *slb, *sub, *xtol, minf, crv;
 	 nlopt_result ret;
 	 quad_model_data qmd;
@@ -181,17 +182,22 @@ static nlopt_result trsapp_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-7 * *delta; /* absolute x tolerance */
 	 }
 	 memset(&step[1], 0, sizeof(double) * *n);
-	 ret = internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, quad_model, &qmd,
-				    1, rho_constraint, delta, sizeof(double),
-				    slb, sub, &step[1], &minf, -HUGE_VAL,
-				    0., 0., 0., xtol, 1000, 0.);
+	 opt = nlopt_create(NLOPT_LD_MMA, *n);
+	 nlopt_set_min_objective(opt, quad_model, &qmd);
+	 nlopt_add_inequality_constraint(opt, rho_constraint, delta, 0.0);
+	 nlopt_set_lower_bounds(opt, slb);
+	 nlopt_set_upper_bounds(opt, sub);
+	 nlopt_set_xtol_abs(opt, xtol);
+	 nlopt_set_maxeval(opt, 1000);
+	 ret = nlopt_optimize(opt, &step[1], &minf);
+	 nlopt_destroy(opt);
 	 if (rho_constraint(*n, &step[1], 0, delta) > -1e-6*(*delta)*(*delta))
 	      crv = 0;
 	 else {
 	      for (j = 1; j <= *n; ++j) d__[j] = step[j] - xopt[j];
 	      quad_model(*n, &d__[1], &g[1], &qmd);
-	      crv = gg = 0; 
-	      for (j = 1; j <= *n; ++j) { 
+	      crv = gg = 0;
+	      for (j = 1; j <= *n; ++j) {
 		   crv += step[j] * (g[j] - gq[j]);
 		   gg += step[j] * step[j];
 	      }
@@ -203,7 +209,7 @@ static nlopt_result trsapp_(int *n, int *npt, double *xopt,
 	 *crvmin = crv;
 	 return ret;
     }
-    
+
     /* Function Body */
     half = .5;
     zero = 0.;
@@ -486,15 +492,15 @@ L170:
 /*************************************************************************/
 /* bigden.f */
 
-static nlopt_result bigden_(int *n, int *npt, double *xopt, 
-		    double *xpt, double *bmat, double *zmat, int *idz, 
-		    int *ndim, int *kopt, int *knew, double *d__, 
-		    double *w, double *vlag, double *beta, double *s, 
+static nlopt_result bigden_(int *n, int *npt, double *xopt,
+		    double *xpt, double *bmat, double *zmat, int *idz,
+		    int *ndim, int *kopt, int *knew, double *d__,
+		    double *w, double *vlag, double *beta, double *s,
 		    double *wvec, double *prod,
 		    const double *xbase, const double *lb, const double *ub)
 {
     /* System generated locals */
-    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1, 
+    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1,
 	    zmat_offset, wvec_dim1, wvec_offset, prod_dim1, prod_offset, i__1,
 	     i__2;
     double d__1;
@@ -513,7 +519,7 @@ static nlopt_result bigden_(int *n, int *npt, double *xopt,
     int iterc;
     double tempa, tempb, tempc;
     int isave;
-    double ssden, dtest, quart, xoptd, twopi, xopts, denold, denmax, 
+    double ssden, dtest, quart, xoptd, twopi, xopts, denold, denmax,
 	    densav, dstemp, sumold, sstemp, xoptsq;
 
 
@@ -754,7 +760,7 @@ L70:
 		i__2 = *n;
 		for (j = 1; j <= i__2; ++j) {
 /* L160: */
-		    sum += bmat[k + j * bmat_dim1] * wvec[*npt + j + jc * 
+		    sum += bmat[k + j * bmat_dim1] * wvec[*npt + j + jc *
 			    wvec_dim1];
 		}
 /* L170: */
@@ -780,7 +786,7 @@ L70:
     for (k = 1; k <= i__1; ++k) {
 	sum = zero;
 	for (i__ = 1; i__ <= 5; ++i__) {
-	    par[i__ - 1] = half * prod[k + i__ * prod_dim1] * wvec[k + i__ * 
+	    par[i__ - 1] = half * prod[k + i__ * prod_dim1] * wvec[k + i__ *
 		    wvec_dim1];
 /* L200: */
 	    sum += par[i__ - 1];
@@ -788,30 +794,30 @@ L70:
 	den[0] = den[0] - par[0] - sum;
 	tempa = prod[k + prod_dim1] * wvec[k + (wvec_dim1 << 1)] + prod[k + (
 		prod_dim1 << 1)] * wvec[k + wvec_dim1];
-	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + (wvec_dim1 << 2)] + 
+	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + (wvec_dim1 << 2)] +
 		prod[k + (prod_dim1 << 2)] * wvec[k + (wvec_dim1 << 1)];
-	tempc = prod[k + prod_dim1 * 3] * wvec[k + wvec_dim1 * 5] + prod[k + 
+	tempc = prod[k + prod_dim1 * 3] * wvec[k + wvec_dim1 * 5] + prod[k +
 		prod_dim1 * 5] * wvec[k + wvec_dim1 * 3];
 	den[1] = den[1] - tempa - half * (tempb + tempc);
 	den[5] -= half * (tempb - tempc);
-	tempa = prod[k + prod_dim1] * wvec[k + wvec_dim1 * 3] + prod[k + 
+	tempa = prod[k + prod_dim1] * wvec[k + wvec_dim1 * 3] + prod[k +
 		prod_dim1 * 3] * wvec[k + wvec_dim1];
-	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + wvec_dim1 * 5] + prod[k 
+	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + wvec_dim1 * 5] + prod[k
 		+ prod_dim1 * 5] * wvec[k + (wvec_dim1 << 1)];
-	tempc = prod[k + prod_dim1 * 3] * wvec[k + (wvec_dim1 << 2)] + prod[k 
+	tempc = prod[k + prod_dim1 * 3] * wvec[k + (wvec_dim1 << 2)] + prod[k
 		+ (prod_dim1 << 2)] * wvec[k + wvec_dim1 * 3];
 	den[2] = den[2] - tempa - half * (tempb - tempc);
 	den[6] -= half * (tempb + tempc);
 	tempa = prod[k + prod_dim1] * wvec[k + (wvec_dim1 << 2)] + prod[k + (
 		prod_dim1 << 2)] * wvec[k + wvec_dim1];
 	den[3] = den[3] - tempa - par[1] + par[2];
-	tempa = prod[k + prod_dim1] * wvec[k + wvec_dim1 * 5] + prod[k + 
+	tempa = prod[k + prod_dim1] * wvec[k + wvec_dim1 * 5] + prod[k +
 		prod_dim1 * 5] * wvec[k + wvec_dim1];
-	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + wvec_dim1 * 3] + prod[k 
+	tempb = prod[k + (prod_dim1 << 1)] * wvec[k + wvec_dim1 * 3] + prod[k
 		+ prod_dim1 * 3] * wvec[k + (wvec_dim1 << 1)];
 	den[4] = den[4] - tempa - half * tempb;
 	den[7] = den[7] - par[3] + par[4];
-	tempa = prod[k + (prod_dim1 << 2)] * wvec[k + wvec_dim1 * 5] + prod[k 
+	tempa = prod[k + (prod_dim1 << 2)] * wvec[k + wvec_dim1 * 5] + prod[k
 		+ prod_dim1 * 5] * wvec[k + (wvec_dim1 << 2)];
 /* L210: */
 	den[8] -= half * tempa;
@@ -844,7 +850,7 @@ L70:
     denex[4] = alpha * den[4] + tempa + prod[*knew + (prod_dim1 << 1)] * prod[
 	    *knew + prod_dim1 * 3];
     denex[7] = alpha * den[7] + par[3] - par[4];
-    denex[8] = alpha * den[8] + prod[*knew + (prod_dim1 << 2)] * prod[*knew + 
+    denex[8] = alpha * den[8] + prod[*knew + (prod_dim1 << 2)] * prod[*knew +
 	    prod_dim1 * 5];
 
 /* Seek the value of the angle that maximizes the modulus of DENOM. */
@@ -1022,10 +1028,11 @@ typedef struct {
 } lag_data;
 
 /* the Lagrange function, whose absolute value biglag maximizes */
-static double lag(int n, const double *dx, double *grad, void *data)
+static double lag(unsigned n, const double *dx, double *grad, void *data)
 {
      lag_data *d = (lag_data *) data;
-     int i, j, npt = d->npt, ndim = d->ndim;
+     int i, npt = d->npt, ndim = d->ndim;
+	 unsigned j;
      const double *hcol = d->hcol, *xpt = d->xpt, *bmat = d->bmat, *xopt = d->xopt;
      double val = 0;
      for (j = 0; j < n; ++j) {
@@ -1049,15 +1056,15 @@ static double lag(int n, const double *dx, double *grad, void *data)
      return val;
 }
 
-static nlopt_result biglag_(int *n, int *npt, double *xopt, 
-		    double *xpt, double *bmat, double *zmat, int *idz, 
-		    int *ndim, int *knew, double *delta, double *d__, 
-		    double *alpha, double *hcol, double *gc, double *gd, 
+static nlopt_result biglag_(int *n, int *npt, double *xopt,
+		    double *xpt, double *bmat, double *zmat, int *idz,
+		    int *ndim, int *knew, double *delta, double *d__,
+		    double *alpha, double *hcol, double *gc, double *gd,
 		    double *s, double *w,
 		    const double *xbase, const double *lb, const double *ub)
 {
     /* System generated locals */
-    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1, 
+    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1,
 	    zmat_offset, i__1, i__2;
     double d__1;
 
@@ -1065,7 +1072,7 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
     int i__, j, k;
     double dd, gg;
     int iu;
-    double sp, ss, cf1, cf2, cf3, cf4, cf5, dhd, cth, one, tau, sth, sum, 
+    double sp, ss, cf1, cf2, cf3, cf4, cf5, dhd, cth, one, tau, sth, sum,
 	    half, temp, step;
     int nptm;
     double zero, angle, scale, denom;
@@ -1214,6 +1221,8 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
 
     if (lb && ub) {
 	 double minf, *dlb, *dub, *xtol;
+	 nlopt_opt opt;
+	 nlopt_result ret;
 	 lag_data ld;
 	 ld.npt = *npt;
 	 ld.ndim = *ndim;
@@ -1239,10 +1248,17 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-5 * *delta;
 	 }
 	 ld.flipsign = lag(*n, &d__[1], 0, &ld) > 0; /* maximize if > 0 */
-	 return internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, lag, &ld,
-				    1, rho_constraint, delta, sizeof(double),
-				    dlb, dub, &d__[1], &minf, -HUGE_VAL,
-				    0., 0., 0., xtol, 1000, 0.);
+
+	 opt = nlopt_create(NLOPT_LD_MMA, *n);
+	 nlopt_set_min_objective(opt, lag, &ld);
+	 nlopt_add_inequality_constraint(opt, rho_constraint, delta, 0.0);
+	 nlopt_set_lower_bounds(opt, dlb);
+	 nlopt_set_upper_bounds(opt, dub);
+	 nlopt_set_xtol_abs(opt, xtol);
+	 nlopt_set_maxeval(opt, 1000);
+	 ret = nlopt_optimize(opt, &d__[1], &minf);
+	 nlopt_destroy(opt);
+	 return ret;
     }
 
 /* Begin the iteration by overwriting S with a vector that has the */
@@ -1377,8 +1393,8 @@ L160:
 /*************************************************************************/
 /* update.f */
 
-static void update_(int *n, int *npt, double *bmat, 
-	double *zmat, int *idz, int *ndim, double *vlag, 
+static void update_(int *n, int *npt, double *bmat,
+	double *zmat, int *idz, int *ndim, double *vlag,
 	double *beta, int *knew, double *w)
 {
     /* System generated locals */
@@ -1434,9 +1450,9 @@ static void update_(int *n, int *npt, double *bmat,
 	    tempb = zmat[*knew + j * zmat_dim1] / temp;
 	    i__2 = *npt;
 	    for (i__ = 1; i__ <= i__2; ++i__) {
-		temp = tempa * zmat[i__ + jl * zmat_dim1] + tempb * zmat[i__ 
+		temp = tempa * zmat[i__ + jl * zmat_dim1] + tempb * zmat[i__
 			+ j * zmat_dim1];
-		zmat[i__ + j * zmat_dim1] = tempa * zmat[i__ + j * zmat_dim1] 
+		zmat[i__ + j * zmat_dim1] = tempa * zmat[i__ + j * zmat_dim1]
 			- tempb * zmat[i__ + jl * zmat_dim1];
 /* L10: */
 		zmat[i__ + jl * zmat_dim1] = temp;
@@ -1482,7 +1498,7 @@ static void update_(int *n, int *npt, double *bmat,
 	i__1 = *npt;
 	for (i__ = 1; i__ <= i__1; ++i__) {
 /* L40: */
-	    zmat[i__ + zmat_dim1] = tempa * zmat[i__ + zmat_dim1] - tempb * 
+	    zmat[i__ + zmat_dim1] = tempa * zmat[i__ + zmat_dim1] - tempb *
 		    vlag[i__];
 	}
 	if (*idz == 1 && temp < zero) {
@@ -1508,10 +1524,10 @@ static void update_(int *n, int *npt, double *bmat,
 	scalb_ = scala * sqrt((fabs(denom)));
 	i__1 = *npt;
 	for (i__ = 1; i__ <= i__1; ++i__) {
-	    zmat[i__ + ja * zmat_dim1] = scala * (tau * zmat[i__ + ja * 
+	    zmat[i__ + ja * zmat_dim1] = scala * (tau * zmat[i__ + ja *
 		    zmat_dim1] - temp * vlag[i__]);
 /* L50: */
-	    zmat[i__ + jb * zmat_dim1] = scalb_ * (zmat[i__ + jb * zmat_dim1] 
+	    zmat[i__ + jb * zmat_dim1] = scalb_ * (zmat[i__ + jb * zmat_dim1]
 		    - tempa * w[i__] - tempb * vlag[i__]);
 	}
 	if (denom <= zero) {
@@ -1548,10 +1564,10 @@ static void update_(int *n, int *npt, double *bmat,
 	tempb = (-(*beta) * w[jp] - tau * vlag[jp]) / denom;
 	i__2 = jp;
 	for (i__ = 1; i__ <= i__2; ++i__) {
-	    bmat[i__ + j * bmat_dim1] = bmat[i__ + j * bmat_dim1] + tempa * 
+	    bmat[i__ + j * bmat_dim1] = bmat[i__ + j * bmat_dim1] + tempa *
 		    vlag[i__] + tempb * w[i__];
 	    if (i__ > *npt) {
-		bmat[jp + (i__ - *npt) * bmat_dim1] = bmat[i__ + j * 
+		bmat[jp + (i__ - *npt) * bmat_dim1] = bmat[i__ + j *
 			bmat_dim1];
 	    }
 /* L70: */
@@ -1564,18 +1580,18 @@ static void update_(int *n, int *npt, double *bmat,
 /*************************************************************************/
 /* newuob.f */
 
-static nlopt_result newuob_(int *n, int *npt, double *x, 
-			    double *rhobeg, 
+static nlopt_result newuob_(int *n, int *npt, double *x,
+			    double *rhobeg,
 			    const double *lb, const double *ub,
 			    nlopt_stopping *stop, double *minf,
 			    newuoa_func calfun, void *calfun_data,
-		    double *xbase, double *xopt, double *xnew, 
-		    double *xpt, double *fval, double *gq, double *hq, 
-		    double *pq, double *bmat, double *zmat, int *ndim, 
+		    double *xbase, double *xopt, double *xnew,
+		    double *xpt, double *fval, double *gq, double *hq,
+		    double *pq, double *bmat, double *zmat, int *ndim,
 		    double *d__, double *vlag, double *w)
 {
     /* System generated locals */
-    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1, 
+    int xpt_dim1, xpt_offset, bmat_dim1, bmat_offset, zmat_dim1,
 	    zmat_offset, i__1, i__2, i__3;
     double d__1, d__2, d__3;
 
@@ -1594,7 +1610,7 @@ static nlopt_result newuob_(int *n, int *npt, double *x,
     int knew;
     double temp, suma, sumb, fopt = HUGE_VAL, bsum, gqsq;
     int kopt, nptm;
-    double zero, xipt = 0.0, xjpt = 0.0, sumz, diffa = 0.0, diffb = 0.0, diffc = 0.0, hdiag, alpha = 0.0, 
+    double zero, xipt = 0.0, xjpt = 0.0, sumz, diffa = 0.0, diffb = 0.0, diffc = 0.0, hdiag, alpha = 0.0,
 	    delta, recip, reciq, fsave;
     int ksave, nfsav = 0, itemp;
     double dnorm = 0.0, ratio = 0.0, dstep, tenth, vquad;
@@ -1899,7 +1915,7 @@ L120:
 		i__3 = i__;
 		for (j = 1; j <= i__3; ++j) {
 /* L140: */
-		    bmat[ip + j * bmat_dim1] = bmat[ip + j * bmat_dim1] + 
+		    bmat[ip + j * bmat_dim1] = bmat[ip + j * bmat_dim1] +
 			    vlag[i__] * w[j] + w[i__] * vlag[j];
 		}
 	    }
@@ -1931,7 +1947,7 @@ L120:
 		i__1 = *npt;
 		for (i__ = 1; i__ <= i__1; ++i__) {
 /* L170: */
-		    bmat[i__ + j * bmat_dim1] += sum * zmat[i__ + k * 
+		    bmat[i__ + j * bmat_dim1] += sum * zmat[i__ + k *
 			    zmat_dim1];
 		}
 	    }
@@ -1972,7 +1988,7 @@ L120:
 		gq[i__] += hq[ih] * xopt[j];
 		hq[ih] = hq[ih] + w[i__] * xopt[j] + xopt[i__] * w[j];
 /* L200: */
-		bmat[*npt + i__ + j * bmat_dim1] = bmat[*npt + j + i__ * 
+		bmat[*npt + i__ + j * bmat_dim1] = bmat[*npt + j + i__ *
 			bmat_dim1];
 	    }
 	}
@@ -1990,10 +2006,10 @@ L120:
 /* cancellation in DENOM. */
 
     if (knew > 0) {
-       rc2 = 
+       rc2 =
 	 biglag_(n, npt, &xopt[1], &xpt[xpt_offset], &bmat[bmat_offset], &zmat[
 		zmat_offset], &idz, ndim, &knew, &dstep, &d__[1], &alpha, &
-		vlag[1], &vlag[*npt + 1], &w[1], &w[np], &w[np + *n], 
+		vlag[1], &vlag[*npt + 1], &w[1], &w[np], &w[np + *n],
 		&xbase[1], lb, ub);
        if (rc2 < 0) { rc = rc2; goto L530; }
     }
@@ -2073,10 +2089,10 @@ L120:
 	if (d__1 == 0) { rc = NLOPT_ROUNDOFF_LIMITED; goto L530; }
 	temp = one + alpha * beta / (d__1 * d__1);
 	if (fabs(temp) <= .8) {
-	  rc2 = 
+	  rc2 =
 	    bigden_(n, npt, &xopt[1], &xpt[xpt_offset], &bmat[bmat_offset], &
 		    zmat[zmat_offset], &idz, ndim, &kopt, &knew, &d__[1], &w[
-		    1], &vlag[1], &beta, &xnew[1], &w[*ndim + 1], &w[*ndim * 
+		    1], &vlag[1], &beta, &xnew[1], &w[*ndim + 1], &w[*ndim *
 		    6 + 1], &xbase[1], lb, ub);
 	  if (rc2 < 0) { rc = rc2; goto L530; }
 	}
@@ -2113,7 +2129,7 @@ L310:
        rc = NLOPT_MINF_MAX_REACHED;
        goto L530;
     }
-    
+
     if (nf <= *npt) {
 	goto L70;
     }
@@ -2476,7 +2492,7 @@ nlopt_result newuoa(int n, int npt, double *x,
 		    newuoa_func calfun, void *calfun_data)
 {
     /* Local variables */
-    int id, np, iw, igq, ihq, ixb, ifv, ipq, ivl, ixn, ixo, ixp, ndim, 
+    int id, np, iw, igq, ihq, ixb, ifv, ipq, ivl, ixn, ixo, ixp, ndim,
 	    nptm, ibmat, izmat;
     nlopt_result ret;
     double *w;
@@ -2551,8 +2567,8 @@ nlopt_result newuoa(int n, int npt, double *x,
 /* The partition requires the first NPT*(NPT+N)+5*N*(N+3)/2 elements of */
 /* W plus the space that is needed by the last array of NEWUOB. */
 
-    ret = newuob_(&n, &npt, &x[1], &rhobeg, 
-		  lb, ub, stop, minf, calfun, calfun_data, 
+    ret = newuob_(&n, &npt, &x[1], &rhobeg,
+		  lb, ub, stop, minf, calfun, calfun_data,
 		  &w[ixb], &w[ixo], &w[ixn], &w[ixp], &w[ifv],
 		  &w[igq], &w[ihq], &w[ipq], &w[ibmat], &w[izmat],
 		  &ndim, &w[id], &w[ivl], &w[iw]);

--- a/src/algs/newuoa/newuoa.c
+++ b/src/algs/newuoa/newuoa.c
@@ -181,7 +181,7 @@ static nlopt_result trsapp_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-7 * *delta; /* absolute x tolerance */
 	 }
 	 memset(&step[1], 0, sizeof(double) * *n);
-	 ret = nlopt_minimize_constrained(NLOPT_LD_MMA, *n, quad_model, &qmd,
+	 ret = internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, quad_model, &qmd,
 				    1, rho_constraint, delta, sizeof(double),
 				    slb, sub, &step[1], &minf, -HUGE_VAL,
 				    0., 0., 0., xtol, 1000, 0.);
@@ -1070,7 +1070,8 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
     int nptm;
     double zero, angle, scale, denom;
     int iterc, isave;
-    double delsq, tempa, tempb = 0.0, twopi, taubeg, tauold, taumax;
+    /* Note: tempa is initialized below, initialization here is only used to avoid 'maybe-uninitialized' warning */
+    double delsq, tempa = 0.0, tempb = 0.0, twopi, taubeg, tauold, taumax;
 
 
 /* N is the number of variables. */
@@ -1238,7 +1239,7 @@ static nlopt_result biglag_(int *n, int *npt, double *xopt,
 	      xtol[j] = 1e-5 * *delta;
 	 }
 	 ld.flipsign = lag(*n, &d__[1], 0, &ld) > 0; /* maximize if > 0 */
-	 return nlopt_minimize_constrained(NLOPT_LD_MMA, *n, lag, &ld,
+	 return internal_nlopt_minimize_constrained(NLOPT_LD_MMA, *n, lag, &ld,
 				    1, rho_constraint, delta, sizeof(double),
 				    dlb, dub, &d__[1], &minf, -HUGE_VAL,
 				    0., 0., 0., xtol, 1000, 0.);

--- a/src/algs/slsqp/slsqp.c
+++ b/src/algs/slsqp/slsqp.c
@@ -2497,9 +2497,11 @@ nlopt_result nlopt_slsqp(unsigned n, nlopt_func f, void *f_data,
 	  switch (mode) {
 	  case -1:  /* objective & gradient evaluation */
 	      if (prev_mode == -2 && !want_grad) break; /* just evaluated this point */
+	      /* fall through */
 	  case -2:
 	      eval_f_and_grad:
 	      want_grad = 1;
+	      /* fall through */
 	  case 1:{ /* don't need grad unless we don't have it yet */
 	      double *newgrad = 0;
 	      double *newcgrad = 0;

--- a/src/algs/stogo/global.h
+++ b/src/algs/stogo/global.h
@@ -49,6 +49,7 @@ public:
        switch (which) {
 	   case OBJECTIVE_AND_GRADIENT:
 		Gradient(xy, grad);
+		return Objective(xy);
 	   case OBJECTIVE_ONLY:
 		return Objective(xy);
 	   case GRADIENT_ONLY:

--- a/src/api/deprecated.c
+++ b/src/api/deprecated.c
@@ -162,6 +162,11 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_econstrained(nlopt_algorithm algorithm
     return ret;
 }
 
+/* don't emit inner deprecated warnings */
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 nlopt_result NLOPT_STDCALL nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, const double *lb, const double *ub,   /* bounds */
                                                       double *x,        /* in: initial guess, out: minimizer */
                                                       double *minf,     /* out: minimum */
@@ -171,7 +176,27 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_constrained(nlopt_algorithm algorithm,
                                        m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
 }
 
+/* used internally, without deprecation warning */
+nlopt_result NLOPT_STDCALL internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, const double *lb, const double *ub,   /* bounds */
+                                                      double *x,        /* in: initial guess, out: minimizer */
+                                                      double *minf,     /* out: minimum */
+                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
+{
+    return nlopt_minimize_econstrained(algorithm, n, f, f_data,
+                                       m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
+}
+
+
 nlopt_result NLOPT_STDCALL nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
+                                          double *x,    /* in: initial guess, out: minimizer */
+                                          double *minf, /* out: minimum */
+                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
+{
+    return nlopt_minimize_constrained(algorithm, n, f, f_data, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, maxeval, maxtime);
+}
+
+/* used internally, without deprecation warning */
+nlopt_result NLOPT_STDCALL internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
                                           double *x,    /* in: initial guess, out: minimizer */
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)

--- a/src/api/deprecated.c
+++ b/src/api/deprecated.c
@@ -7,17 +7,17 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include "nlopt.h"
@@ -176,27 +176,8 @@ nlopt_result NLOPT_STDCALL nlopt_minimize_constrained(nlopt_algorithm algorithm,
                                        m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
 }
 
-/* used internally, without deprecation warning */
-nlopt_result NLOPT_STDCALL internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, const double *lb, const double *ub,   /* bounds */
-                                                      double *x,        /* in: initial guess, out: minimizer */
-                                                      double *minf,     /* out: minimum */
-                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
-{
-    return nlopt_minimize_econstrained(algorithm, n, f, f_data,
-                                       m, fc, fc_data, fc_datum_size, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, ftol_rel, ftol_abs, maxeval, maxtime);
-}
-
 
 nlopt_result NLOPT_STDCALL nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
-                                          double *x,    /* in: initial guess, out: minimizer */
-                                          double *minf, /* out: minimum */
-                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)
-{
-    return nlopt_minimize_constrained(algorithm, n, f, f_data, 0, NULL, NULL, 0, lb, ub, x, minf, minf_max, ftol_rel, ftol_abs, xtol_rel, xtol_abs, maxeval, maxtime);
-}
-
-/* used internally, without deprecation warning */
-nlopt_result NLOPT_STDCALL internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, const double *lb, const double *ub, /* bounds */
                                           double *x,    /* in: initial guess, out: minimizer */
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime)

--- a/src/api/f77funcs.h
+++ b/src/api/f77funcs.h
@@ -19,6 +19,9 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
  */
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__==3 && __GNUC_MINOR__ > 0))
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 /* Fortran API wrappers, using the F77 macro defined in f77api.c.
    This header file is #included one or more times from f77api.c

--- a/src/api/nlopt.h
+++ b/src/api/nlopt.h
@@ -301,25 +301,11 @@ NLOPT_EXTERN(nlopt_result) nlopt_minimize(nlopt_algorithm algorithm, int n, nlop
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
 
-/* this is still used internally by a few algorithms, it's the same as nlopt_minimize, but without the deprecation */
-NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data,
-                                          const double *lb, const double *ub, /* bounds */
-                                          double *x,    /* in: initial guess, out: minimizer */
-                                          double *minf, /* out: minimum */
-                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
-
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
                                                       const double *lb, const double *ub,   /* bounds */
                                                       double *x,        /* in: initial guess, out: minimizer */
                                                       double *minf,     /* out: minimum */
                                                       double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
-
-/* this is still used internally by a few algorithms, it's the same as nlopt_minimize_constrained, but without the deprecation */
-NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
-                                                      const double *lb, const double *ub,   /* bounds */
-                                                      double *x,        /* in: initial guess, out: minimizer */
-                                                      double *minf,     /* out: minimum */
-                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
 
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_econstrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, int p, nlopt_func_old h, void *h_data, ptrdiff_t h_datum_size,
                                                        const double *lb, const double *ub,   /* bounds */

--- a/src/api/nlopt.h
+++ b/src/api/nlopt.h
@@ -301,11 +301,25 @@ NLOPT_EXTERN(nlopt_result) nlopt_minimize(nlopt_algorithm algorithm, int n, nlop
                                           double *minf, /* out: minimum */
                                           double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
 
+/* this is still used internally by a few algorithms, it's the same as nlopt_minimize, but without the deprecation */
+NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data,
+                                          const double *lb, const double *ub, /* bounds */
+                                          double *x,    /* in: initial guess, out: minimizer */
+                                          double *minf, /* out: minimum */
+                                          double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
+
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
                                                       const double *lb, const double *ub,   /* bounds */
                                                       double *x,        /* in: initial guess, out: minimizer */
                                                       double *minf,     /* out: minimum */
                                                       double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime) NLOPT_DEPRECATED;
+
+/* this is still used internally by a few algorithms, it's the same as nlopt_minimize_constrained, but without the deprecation */
+NLOPT_EXTERN(nlopt_result) internal_nlopt_minimize_constrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size,
+                                                      const double *lb, const double *ub,   /* bounds */
+                                                      double *x,        /* in: initial guess, out: minimizer */
+                                                      double *minf,     /* out: minimum */
+                                                      double minf_max, double ftol_rel, double ftol_abs, double xtol_rel, const double *xtol_abs, int maxeval, double maxtime);
 
 NLOPT_EXTERN(nlopt_result) nlopt_minimize_econstrained(nlopt_algorithm algorithm, int n, nlopt_func_old f, void *f_data, int m, nlopt_func_old fc, void *fc_data, ptrdiff_t fc_datum_size, int p, nlopt_func_old h, void *h_data, ptrdiff_t h_datum_size,
                                                        const double *lb, const double *ub,   /* bounds */


### PR DESCRIPTION
 - remove set but not used variables
 - (void) cast unused function arguments
 - create internal function duplicates for some actually
   deprecated functions, for the f77 files disable
   the deprecation warning completely.
 - add warning flags to travis

Note: some of the maybe-unitialized warnings do not
  show in gcc 7.3.0, but travis seems to use a different one.

This closes #226.