### PR TITLE
c89 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-std=c89 -pedantic -Wall -Wextra -Werror' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-std=c89 -pedantic -D_POSIX_C_SOURCE=200112L -Wall -Wextra -Werror' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
         - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - pip install mkdocs python-markdown-math --user
         - PATH=$PATH:~/.local/bin mkdocs build
         - mkdir build && pushd build
-        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
+        - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-std=c89 -pedantic -Wall -Wextra -Werror' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
         - make install -j2 && ctest -j2 --output-on-failure
         - rm -rf * ~/.local
         - cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ branches:
     - master
 environment:
   matrix:
+    - CMAKE_PLATFORM: "Visual Studio 10 2010"
     - CMAKE_PLATFORM: "Visual Studio 14 2015"
     - CMAKE_PLATFORM: "Visual Studio 14 2015 Win64"
 install:

--- a/src/algs/ags/ags.cc
+++ b/src/algs/ags/ags.cc
@@ -36,7 +36,7 @@ int ags_minimize(unsigned n, nlopt_func func, void *data, unsigned m, nlopt_cons
   {
     if (fc[i].m != 1)
       return NLOPT_INVALID_ARGS;
-    functions.push_back([fc, data, n, i](const double* x) {
+    functions.push_back([fc, n, i](const double* x) {
       double val = 0;
       nlopt_eval_constraint(&val, NULL, &fc[i], n, x);
       return val;

--- a/src/algs/ags/ags.h
+++ b/src/algs/ags/ags.h
@@ -10,19 +10,20 @@
 extern "C" {
 #endif
 
-//The algorithm supports 3 types of stop criterions: stop by execution time, stop by value and stop by exceeding limit of iterations.
+/* The algorithm supports 3 types of stop criterions: stop by execution time, stop by value and stop by exceeding limit of iterations. */
 
 int ags_minimize(unsigned n, nlopt_func func, void *data, unsigned m, nlopt_constraint *fc,
                  double *x, double *minf, const double *l, const double *u, nlopt_stopping *stop);
 
-extern double ags_eps; //method tolerance in Holder metric on 1d interval. Less value -- better search precision, less probability of early stop.
-extern double ags_r; //reliability parameter. Higher value of r -- slower convergence, higher chance to cache the global minima.
-extern double eps_res; // parameter which prevents method from paying too much attention to constraints. Greater values of this parameter speed up convergence,
-// but global minima can be lost.
-extern unsigned evolvent_density; // density of evolvent. By default density is 2^-12 on hybercube [0,1]^N,
-// which means that maximum search accuracyis 2^-12. If search hypercube is large the density can be increased accordingly to achieve better accuracy.
-extern int ags_refine_loc; //refine the final optimum using built-in local optimizer
-extern int ags_verbose; //print additional info
+extern double ags_eps; /* method tolerance in Holder metric on 1d interval. Less value -- better search precision, less probability of early stop. */
+extern double ags_r; /* reliability parameter. Higher value of r -- slower convergence, higher chance to cache the global minima. */
+extern double eps_res; /* parameter which prevents method from paying too much attention to constraints. Greater values of this parameter speed up convergence,
+                          but global minima can be lost. */
+extern unsigned evolvent_density; /* density of evolvent. By default density is 2^-12 on hybercube [0,1]^N,
+                                     which means that maximum search accuracyis 2^-12. If search hypercube is large the density
+                                     can be increased accordingly to achieve better accuracy. */
+extern int ags_refine_loc; /* refine the final optimum using built-in local optimizer */
+extern int ags_verbose; /* print additional info */
 
 #ifdef __cplusplus
 }

--- a/src/algs/bobyqa/bobyqa.c
+++ b/src/algs/bobyqa/bobyqa.c
@@ -157,7 +157,7 @@ static nlopt_result rescue_(int *n, int *npt, const double *xl, const double *xu
     /* Local variables */
     double f;
     int i__, j, k, ih, jp, ip, iq, np, iw;
-    double xp = 0.0, xq, den;
+    double xp = 0.0, xq = 0.0, den;
     int ihp = 0;
     double one;
     int ihq, jpn, kpt;

--- a/src/algs/cdirect/hybrid.c
+++ b/src/algs/cdirect/hybrid.c
@@ -78,7 +78,6 @@ static nlopt_result optimize_rect(double *r, params *p)
      double minf;
      nlopt_stopping *stop = p->stop;
      nlopt_result ret;
-     nlopt_opt opt;
 
      if (stop->maxeval > 0 &&
 	 *(stop->nevals_p) >= stop->maxeval) return NLOPT_MAXEVAL_REACHED;

--- a/src/algs/direct/DIRserial.c
+++ b/src/algs/direct/DIRserial.c
@@ -14,23 +14,23 @@
 /* +-----------------------------------------------------------------------+ */
 /* | SUBROUTINE for sampling.                                              | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirsamplef_(doublereal *c__, integer *arrayi, doublereal 
-	*delta, integer *sample, integer *new__, integer *length, 
-	FILE *logfile, doublereal *f, integer *free, integer *maxi, 
+/* Subroutine */ void direct_dirsamplef_(doublereal *c__, integer *arrayi, doublereal
+	*delta, integer *sample, integer *new__, integer *length,
+	FILE *logfile, doublereal *f, integer *free, integer *maxi,
 	integer *point, fp fcn, doublereal *x, doublereal *l, doublereal *
-	minf, integer *minpos, doublereal *u, integer *n, integer *maxfunc, 
+	minf, integer *minpos, doublereal *u, integer *n, integer *maxfunc,
 	const integer *maxdeep, integer *oops, doublereal *fmax, integer *
 	ifeasiblef, integer *iinfesiblef, void *fcn_data, int *force_stop)
 {
-    (void) logfile; (void) free; (void) maxfunc; (void) maxdeep; (void) oops;
-    (void) delta; (void) sample;
-
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
     doublereal d__1;
 
     /* Local variables */
     integer i__, j, helppoint, pos, kret;
+
+    (void) logfile; (void) free; (void) maxfunc; (void) maxdeep; (void) oops;
+    (void) delta; (void) sample;
 
 /* +-----------------------------------------------------------------------+ */
 /* | JG 07/16/01 fcn must be declared external.                            | */
@@ -86,7 +86,7 @@
 	if (force_stop && *force_stop)  /* skip eval after forced stop */
 	     f[(pos << 1) + 1] = *fmax;
 	else
-	     direct_dirinfcn_(fcn, &x[1], &l[1], &u[1], n, &f[(pos << 1) + 1], 
+	     direct_dirinfcn_(fcn, &x[1], &l[1], &u[1], n, &f[(pos << 1) + 1],
 			      &kret, fcn_data);
 	if (force_stop && *force_stop)
 	     kret = -1; /* mark as invalid point */

--- a/src/algs/direct/DIRsubrout.c
+++ b/src/algs/direct/DIRsubrout.c
@@ -30,16 +30,16 @@ static integer c__0 = 0;
 /* | n	   -- the dimension of the problem                                  | */
 /* |                                                                       | */
 /* +-----------------------------------------------------------------------+ */
-integer direct_dirgetlevel_(integer *pos, integer *length, integer *maxfunc, integer 
+integer direct_dirgetlevel_(integer *pos, integer *length, integer *maxfunc, integer
 	*n, integer jones)
 {
-    (void) maxfunc;
-
     /* System generated locals */
     integer length_dim1, length_offset, ret_val, i__1;
 
     /* Local variables */
     integer i__, k, p, help;
+
+    (void) maxfunc;
 
 /* JG 09/15/00 Added variable JONES (see above) */
     /* Parameter adjustments */
@@ -96,7 +96,7 @@ integer direct_dirgetlevel_(integer *pos, integer *length, integer *maxfunc, int
 /* |         Added Ifeasiblef to call to keep track if a feasible point has| */
 /* |         been found.                                                   | */
 /* |    Changed 07/16/01 JG                                                | */
-/* |         Changed if statement to prevent run-time errors.              |                                  
+/* |         Changed if statement to prevent run-time errors.              |
                  | */
 /* +-----------------------------------------------------------------------+ */
 /* Subroutine */ void direct_dirchoose_(integer *anchor, integer *s, integer *actdeep,
@@ -161,7 +161,7 @@ L12:
     novalue = 0;
     if (anchor[-1] > 0) {
 	novalue = anchor[-1];
-	novaluedeep = direct_dirgetlevel_(&novalue, &length[length_offset], maxfunc, 
+	novaluedeep = direct_dirgetlevel_(&novalue, &length[length_offset], maxfunc,
 		n, jones);
     }
     *maxpos = k - 1;
@@ -235,7 +235,7 @@ L12:
 		helplower = *kmax;
 	    }
 	    if (f[(j___ << 1) + 1] - helplower * thirds[s[j + (s_dim1 << 1)]] >
-		     MIN(*minf - epsrel * fabs(*minf), 
+		     MIN(*minf - epsrel * fabs(*minf),
 			 *minf - epsabs)) {
 		if (logfile)
 		     fprintf(logfile, "> minf - epslminfl\n");
@@ -275,13 +275,13 @@ L40:
 	maxpos, integer *point, doublereal *f, const integer *maxdeep, integer *
 	maxfunc, const integer *maxdiv, integer *ierror)
 {
-    (void)  maxdeep; (void) maxfunc;
-
     /* System generated locals */
     integer s_dim1, s_offset, i__1;
 
     /* Local variables */
     integer i__, oldmaxpos, pos, help, iflag, actdeep;
+
+    (void)  maxdeep; (void) maxfunc;
 
 /* +-----------------------------------------------------------------------+ */
 /* | JG 07/16/01 Added flag to prevent run time-errors on some systems.    | */
@@ -345,16 +345,16 @@ L40:
 /* | n	   -- the dimension of the problem                                  | */
 /* |                                                                       | */
 /* +-----------------------------------------------------------------------+ */
-integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc, 
+integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc,
 	integer *n)
 {
-    (void) maxfunc;
-
     /* System generated locals */
     integer length_dim1, length_offset, i__1, i__2, i__3;
 
     /* Local variables */
     integer i__, help;
+
+    (void) maxfunc;
 
     /* Parameter adjustments */
     length_dim1 = *n;
@@ -373,16 +373,16 @@ integer direct_dirgetmaxdeep_(integer *pos, integer *length, integer *maxfunc,
     return help;
 } /* dirgetmaxdeep_ */
 
-static integer isinbox_(doublereal *x, doublereal *a, doublereal *b, integer *n, 
+static integer isinbox_(doublereal *x, doublereal *a, doublereal *b, integer *n,
 	integer *lmaxdim)
 {
-    (void) lmaxdim;
-
     /* System generated locals */
     integer ret_val, i__1;
 
     /* Local variables */
     integer outofbox, i__;
+
+    (void) lmaxdim;
 
     /* Parameter adjustments */
     --b;
@@ -412,19 +412,19 @@ L1010:
 /* | Resort the list so that the infeasible point is in the list with the  | */
 /* | replaced value.                                                       | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ static void dirresortlist_(integer *replace, integer *anchor, 
+/* Subroutine */ static void dirresortlist_(integer *replace, integer *anchor,
 	doublereal *f, integer *point, integer *length, integer *n, integer *
 	maxfunc, integer *maxdim, const integer *maxdeep, FILE *logfile,
 					    integer jones)
 {
-    (void) maxdim; (void) maxdeep;
-
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
     /* Local variables */
     integer i__, l, pos;
     integer start;
+
+    (void) maxdim; (void) maxdeep;
 
 /* +-----------------------------------------------------------------------+ */
 /* | Get the length of the hyper rectangle with infeasible mid point and   | */
@@ -525,14 +525,12 @@ L40:
 /* | If this is the case, replace the function value at the center of the  | */
 /* | hyper rectangle by the lowest function value of a nearby function.    | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirreplaceinf_(integer *free, integer *freeold, 
-	doublereal *f, doublereal *c__, doublereal *thirds, integer *length, 
-	integer *anchor, integer *point, doublereal *c1, doublereal *c2, 
-	integer *maxfunc, const integer *maxdeep, integer *maxdim, integer *n, 
+/* Subroutine */ void direct_dirreplaceinf_(integer *free, integer *freeold,
+	doublereal *f, doublereal *c__, doublereal *thirds, integer *length,
+	integer *anchor, integer *point, doublereal *c1, doublereal *c2,
+	integer *maxfunc, const integer *maxdeep, integer *maxdim, integer *n,
 	FILE *logfile, doublereal *fmax, integer jones)
 {
-    (void) freeold;
-
     /* System generated locals */
     integer c_dim1, c_offset, length_dim1, length_offset, i__1, i__2, i__3;
     doublereal d__1, d__2;
@@ -542,6 +540,8 @@ L40:
     integer i__, j, k, l;
     doublereal x[32], sidelength;
     integer help;
+
+    (void) freeold;
 
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
@@ -612,7 +612,7 @@ L40:
 /* Computing MIN */
 			 d__1 = f[(i__ << 1) + 1], d__2 = f[(k << 1) + 1];
 			 f[(i__ << 1) + 1] = MIN(d__1,d__2);
-			 f[(i__ << 1) + 2] = 1.; 
+			 f[(i__ << 1) + 2] = 1.;
 		    }
 		}
 /* L30: */
@@ -626,8 +626,8 @@ L40:
 			    c_dim1] * c2[l];
 /* L200: */
 		}
-		dirresortlist_(&i__, &anchor[-1], &f[3], &point[1], 
-			       &length[length_offset], n, 
+		dirresortlist_(&i__, &anchor[-1], &f[3], &point[1],
+			       &length[length_offset], n,
 			       maxfunc, maxdim, maxdeep, logfile, jones);
 	    } else {
 /* +-----------------------------------------------------------------------+ */
@@ -650,7 +650,7 @@ L40:
 /* +-----------------------------------------------------------------------+ */
 /* |    SUBROUTINE DIRInsert                                               | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ static void dirinsert_(integer *start, integer *ins, integer *point, 
+/* Subroutine */ static void dirinsert_(integer *start, integer *ins, integer *point,
 	doublereal *f, integer *maxfunc)
 {
     /* System generated locals */
@@ -710,8 +710,6 @@ L40:
 	maxfunc, const integer *maxdeep, integer *n, integer *samp,
 					    integer jones)
 {
-    (void) maxdeep;
-
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
@@ -719,6 +717,8 @@ L40:
     integer j;
     integer pos;
     integer pos1, pos2, deep;
+
+    (void) maxdeep;
 
 /* JG 09/24/00 Changed this to Getlevel */
     /* Parameter adjustments */
@@ -872,21 +872,20 @@ L50:
 /* |    SUBROUTINE DIRSamplepoints                                         | */
 /* |    Subroutine to sample the new points.                               | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirsamplepoints_(doublereal *c__, integer *arrayi, 
-	doublereal *delta, integer *sample, integer *start, integer *length, 
-	FILE *logfile, doublereal *f, integer *free, 
+/* Subroutine */ void direct_dirsamplepoints_(doublereal *c__, integer *arrayi,
+	doublereal *delta, integer *sample, integer *start, integer *length,
+	FILE *logfile, doublereal *f, integer *free,
 	integer *maxi, integer *point, doublereal *x, doublereal *l,
-	 doublereal *minf, integer *minpos, doublereal *u, integer *n, 
+	 doublereal *minf, integer *minpos, doublereal *u, integer *n,
 	integer *maxfunc, const integer *maxdeep, integer *oops)
 {
-    (void) minf; (void) minpos; (void) maxfunc; (void) maxdeep; (void) oops;
-
     /* System generated locals */
     integer length_dim1, length_offset, c_dim1, c_offset, i__1, i__2;
 
     /* Local variables */
     integer j, k, pos;
 
+    (void) minf; (void) minpos; (void) maxfunc; (void) maxdeep; (void) oops;
 
     /* Parameter adjustments */
     --u;
@@ -947,13 +946,11 @@ L50:
 /* |    Changed 02-24-2000                                                 | */
 /* |      Replaced if statement by min (line 367)                          | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirdivide_(integer *new__, integer *currentlength, 
-	integer *length, integer *point, integer *arrayi, integer *sample, 
+/* Subroutine */ void direct_dirdivide_(integer *new__, integer *currentlength,
+	integer *length, integer *point, integer *arrayi, integer *sample,
 	integer *list2, doublereal *w, integer *maxi, doublereal *f, integer *
 	maxfunc, const integer *maxdeep, integer *n)
 {
-    (void) maxfunc; (void) maxdeep;
-
     /* System generated locals */
     integer length_dim1, length_offset, list2_dim1, list2_offset, i__1, i__2;
     doublereal d__1, d__2;
@@ -962,6 +959,7 @@ L50:
     integer i__, j, k, pos, pos2;
     integer start;
 
+    (void) maxfunc; (void) maxdeep;
 
     /* Parameter adjustments */
     f -= 3;
@@ -988,7 +986,7 @@ L50:
 	d__1 = f[(pos << 1) + 1], d__2 = w[j];
 	w[j] = MIN(d__1,d__2);
 	pos = point[pos];
-	dirinsertlist_2__(&start, &j, &k, &list2[list2_offset], &w[1], maxi, 
+	dirinsertlist_2__(&start, &j, &k, &list2[list2_offset], &w[1], maxi,
 		n);
 /* L10: */
     }
@@ -997,10 +995,10 @@ L50:
     for (j = 1; j <= i__1; ++j) {
 	dirsearchmin_(&start, &list2[list2_offset], &pos, &k, n);
 	pos2 = start;
-	length[k + *sample * length_dim1] = *currentlength + 1; 
+	length[k + *sample * length_dim1] = *currentlength + 1;
 	i__2 = *maxi - j + 1;
 	for (i__ = 1; i__ <= i__2; ++i__) {
-	    length[k + pos * length_dim1] = *currentlength + 1; 
+	    length[k + pos * length_dim1] = *currentlength + 1;
 	    pos = point[pos];
 	    length[k + pos * length_dim1] = *currentlength + 1;
 /* JG 07/10/01 pos2 = 0 at the end of the 30-loop. Since we end */
@@ -1052,8 +1050,8 @@ L50:
 /* | The subroutine whose name is passed through the argument fcn.         | */
 /* |                                                                       | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirinfcn_(fp fcn, doublereal *x, doublereal *c1, 
-	doublereal *c2, integer *n, doublereal *f, integer *flag__, 
+/* Subroutine */ void direct_dirinfcn_(fp fcn, doublereal *x, doublereal *c1,
+	doublereal *c2, integer *n, doublereal *f, integer *flag__,
 				       void *fcn_data)
 {
     /* System generated locals */
@@ -1100,13 +1098,13 @@ L50:
 /* Subroutine */ void direct_dirget_i__(integer *length, integer *pos, integer *
 	arrayi, integer *maxi, integer *n, integer *maxfunc)
 {
-    (void) maxfunc;
-
     /* System generated locals */
     integer length_dim1, length_offset, i__1;
 
     /* Local variables */
     integer i__, j, help;
+
+    (void) maxfunc;
 
     /* Parameter adjustments */
     --arrayi;
@@ -1156,18 +1154,18 @@ L50:
 /* |    Changed 01/23/01                                                   | */
 /* |       Added variable Ierror to keep track of errors.                  | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirinit_(doublereal *f, fp fcn, doublereal *c__, 
-	integer *length, integer *actdeep, integer *point, integer *anchor, 
-	integer *free, FILE *logfile, integer *arrayi, 
-	integer *maxi, integer *list2, doublereal *w, doublereal *x, 
-	doublereal *l, doublereal *u, doublereal *minf, integer *minpos, 
+/* Subroutine */ void direct_dirinit_(doublereal *f, fp fcn, doublereal *c__,
+	integer *length, integer *actdeep, integer *point, integer *anchor,
+	integer *free, FILE *logfile, integer *arrayi,
+	integer *maxi, integer *list2, doublereal *w, doublereal *x,
+	doublereal *l, doublereal *u, doublereal *minf, integer *minpos,
 	doublereal *thirds, doublereal *levels, integer *maxfunc, const integer *
 	maxdeep, integer *n, integer *maxor, doublereal *fmax, integer *
 	ifeasiblef, integer *iinfeasible, integer *ierror, void *fcndata,
 	integer jones, double starttime, double maxtime, int *force_stop)
 {
     /* System generated locals */
-    integer c_dim1, c_offset, length_dim1, length_offset, list2_dim1, 
+    integer c_dim1, c_offset, length_dim1, length_offset, list2_dim1,
 	    list2_offset, i__1, i__2;
 
     /* Local variables */
@@ -1287,7 +1285,7 @@ L50:
     new__ = *free;
     direct_dirsamplepoints_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &
 	    length[length_offset], logfile, &f[3], free, maxi, &
-	    point[1], &x[1], &l[1], minf, minpos, &u[1], n, 
+	    point[1], &x[1], &l[1], minf, minpos, &u[1], n,
 	    maxfunc, maxdeep, &oops);
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/23/01 Added error checking.                                     | */
@@ -1302,7 +1300,7 @@ L50:
 /* +-----------------------------------------------------------------------+ */
     direct_dirsamplef_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &length[
 	    length_offset], logfile, &f[3], free, maxi, &point[
-	    1], fcn, &x[1], &l[1], minf, minpos, &u[1], n, maxfunc, 
+	    1], fcn, &x[1], &l[1], minf, minpos, &u[1], n, maxfunc,
 	    maxdeep, &oops, fmax, ifeasiblef, iinfeasible, fcndata,
 	    force_stop);
     if (force_stop && *force_stop) {
@@ -1321,7 +1319,7 @@ L50:
 	return;
     }
     direct_dirdivide_(&new__, &c__0, &length[length_offset], &point[1], &arrayi[1], &
-	    c__1, &list2[list2_offset], &w[1], maxi, &f[3], maxfunc, 
+	    c__1, &list2[list2_offset], &w[1], maxi, &f[3], maxfunc,
 	    maxdeep, n);
     direct_dirinsertlist_(&new__, &anchor[-1], &point[1], &f[3], maxi, &
 	    length[length_offset], maxfunc, maxdeep, n, &c__1, jones);
@@ -1407,7 +1405,7 @@ L50:
 /* |               hyper-box oops is set to 1 and iffco terminates.        | */
 /* |                                                                       | */
 /* +-----------------------------------------------------------------------+ */
-/* Subroutine */ void direct_dirpreprc_(doublereal *u, doublereal *l, integer *n, 
+/* Subroutine */ void direct_dirpreprc_(doublereal *u, doublereal *l, integer *n,
 	doublereal *xs1, doublereal *xs2, integer *oops)
 {
     /* System generated locals */
@@ -1448,21 +1446,20 @@ L50:
     }
 } /* dirpreprc_ */
 
-/* Subroutine */ void direct_dirheader_(FILE *logfile, integer *version, 
+/* Subroutine */ void direct_dirheader_(FILE *logfile, integer *version,
 	doublereal *x, integer *n, doublereal *eps, integer *maxf, integer *
 	maxt, doublereal *l, doublereal *u, integer *algmethod, integer *
-	maxfunc, const integer *maxdeep, doublereal *fglobal, doublereal *fglper, 
+	maxfunc, const integer *maxdeep, doublereal *fglobal, doublereal *fglper,
 	integer *ierror, doublereal *epsfix, integer *iepschange, doublereal *
 	volper, doublereal *sigmaper)
 {
-    (void) maxdeep; (void) ierror;
-
     /* System generated locals */
     integer i__1;
 
     /* Local variables */
     integer imainver, i__, numerrors, isubsubver, ihelp, isubver;
 
+    (void) maxdeep; (void) ierror;
 
 /* +-----------------------------------------------------------------------+ */
 /* | Variables to pass user defined data to the function to be optimized.  | */
@@ -1515,8 +1512,8 @@ L50:
 		 " Measure percentage wanted: %e\n",
 		 imainver, isubver, isubsubver, *n, *eps, *maxf, *maxt,
 		 *fglobal, *fglper, *volper, *sigmaper);
-	 fprintf(logfile, *iepschange == 1 
-		 ? "Epsilon is changed using the Jones formula.\n" 
+	 fprintf(logfile, *iepschange == 1
+		 ? "Epsilon is changed using the Jones formula.\n"
 		 : "Epsilon is constant.\n");
 	 fprintf(logfile, *algmethod == 0
 		 ? "Jones original DIRECT algorithm is used.\n"
@@ -1556,10 +1553,10 @@ L50:
     if (*ierror < 0) {
 	if (logfile) fprintf(logfile, "----------------------------------\n");
 	if (numerrors == 1) {
-	     if (logfile) 
+	     if (logfile)
 		  fprintf(logfile, "WARNING: One error in the input!\n");
 	} else {
-	     if (logfile) 
+	     if (logfile)
 		  fprintf(logfile, "WARNING: %d errors in the input!\n",
 			  numerrors);
 	}
@@ -1573,11 +1570,9 @@ L50:
 } /* dirheader_ */
 
 /* Subroutine */ void direct_dirsummary_(FILE *logfile, doublereal *x, doublereal *
-	l, doublereal *u, integer *n, doublereal *minf, doublereal *fglobal, 
+	l, doublereal *u, integer *n, doublereal *minf, doublereal *fglobal,
 	integer *numfunc, integer *ierror)
 {
-    (void) ierror;
-
     /* Local variables */
     integer i__;
 
@@ -1585,6 +1580,8 @@ L50:
     --u;
     --l;
     --x;
+
+    (void) ierror;
 
     /* Function Body */
     if (logfile) {
@@ -1595,9 +1592,9 @@ L50:
 	      fprintf(logfile, "Final function value is within %g%% of global optimum\n", 100*(*minf - *fglobal) / MAX(1.0, fabs(*fglobal)));
 	 fprintf(logfile, "Index, final solution, x(i)-l(i), u(i)-x(i)\n");
 	 for (i__ = 1; i__ <= *n; ++i__)
-	      fprintf(logfile, "%d, %g, %g, %g\n", i__, x[i__], 
+	      fprintf(logfile, "%d, %g, %g, %g\n", i__, x[i__],
 		      x[i__]-l[i__], u[i__] - x[i__]);
 	 fprintf(logfile, "-----------------------------------------------\n");
-	      
+
     }
 } /* dirsummary_ */

--- a/src/algs/direct/DIRsubrout.c
+++ b/src/algs/direct/DIRsubrout.c
@@ -384,15 +384,10 @@ static integer isinbox_(doublereal *x, doublereal *a, doublereal *b, integer *n,
 
     (void) lmaxdim;
 
-    /* Parameter adjustments */
-    --b;
-    --a;
-    --x;
-
     /* Function Body */
     outofbox = 1;
     i__1 = *n;
-    for (i__ = 1; i__ <= i__1; ++i__) {
+    for (i__ = 0; i__ < i__1; ++i__) {
 	if (a[i__] > x[i__] || b[i__] < x[i__]) {
 	    outofbox = 0;
 	    goto L1010;

--- a/src/algs/esch/esch.c
+++ b/src/algs/esch/esch.c
@@ -57,10 +57,9 @@ typedef struct IndividualStructure {
 } Individual;
 
 static int CompareIndividuals(void *unused, const void *a_, const void *b_) {
-     (void) unused;
-
      const Individual *a = (const Individual *) a_;
      const Individual *b = (const Individual *) b_;
+     (void) unused;
      return a->fitness < b->fitness ? -1 : (a->fitness > b->fitness ? +1 : 0);
 }
 

--- a/src/algs/luksan/plip.c
+++ b/src/algs/luksan/plip.c
@@ -110,18 +110,16 @@
 /* PROBLEMS. */
 
 static void plip_(int *nf, int *nb, double *x, int *
-		  ix, double *xl, double *xu, double *gf, double *s, 
-		  double *xo, double *go, double *so, double *xm, 
-		  double *xr, double *gr, double *xmax, double *tolx, 
-		  double *tolf, double *tolb, double *tolg, 
+		  ix, double *xl, double *xu, double *gf, double *s,
+		  double *xo, double *go, double *so, double *xm,
+		  double *xr, double *gr, double *xmax, double *tolx,
+		  double *tolf, double *tolb, double *tolg,
 		  nlopt_stopping *stop, double *
-		  minf_est, double *gmax, double *f, int *mit, int *mfv, 
-		  int *iest, int *met, int *mf, 
+		  minf_est, double *gmax, double *f, int *mit, int *mfv,
+		  int *iest, int *met, int *mf,
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
-    (void) tolb;
-
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -156,6 +154,8 @@ static void plip_(int *nf, int *nb, double *x, int *
     double snorm;
     int mtesx, ntesx;
     ps1l01_state state;
+
+    (void) tolb;
 
 /*     INITIATION */
 
@@ -281,8 +281,8 @@ static void plip_(int *nf, int *nb, double *x, int *
     if (nlopt_stop_time(stop)) { *iterm = 100; goto L11190; }
 L11120:
     luksan_pytrcg__(nf, nf, &ix[1], &gf[1], &umax, gmax, &kbf, &iold);
-    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg, 
-	    &kd, &stat_1->nit, &kit, mit, &stat_1->nfg, &mfg, 
+    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg,
+	    &kd, &stat_1->nit, &kit, mit, &stat_1->nfg, &mfg,
 	    &ntesx, &mtesx, &ntesf, &mtesf, &ites, &ires1, &ires2, &irest, &
 	    iters, iterm);
     if (*iterm != 0) {
@@ -371,7 +371,7 @@ L11130:
 	goto L11175;
     }
 L11170:
-    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin, 
+    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin,
 	    &rmax, &tols, &tolp, &par1, &par2, &kd, &ld, &stat_1->nit, &kit, &
 	    nred, &mred, &maxst, iest, &inits, &iters, &kters, &mes,
 		    &isys, &state);
@@ -450,9 +450,9 @@ nlopt_result luksan_plip(int n, nlopt_func f, void *f_data,
      }
 
  retry_alloc:
-     work = (double*) malloc(sizeof(double) * (n * 7 + MAX2(n,n*mf) + 
+     work = (double*) malloc(sizeof(double) * (n * 7 + MAX2(n,n*mf) +
 					       MAX2(n,mf)*2));
-     if (!work) { 
+     if (!work) {
 	  if (mf > 0) {
 	       mf = 0; /* allocate minimal memory */
 	       goto retry_alloc;
@@ -480,7 +480,7 @@ nlopt_result luksan_plip(int n, nlopt_func f, void *f_data,
 	arrays to zero by default? */
      memset(xo, 0, sizeof(double) * MAX2(n,n*mf));
 
-     plip_(&n, &nb, x, ix, xl, xu, 
+     plip_(&n, &nb, x, ix, xl, xu,
 	   gf, s, xo, go, so, xm, xr, gr,
 	   &xmax,
 

--- a/src/algs/luksan/plis.c
+++ b/src/algs/luksan/plis.c
@@ -104,17 +104,15 @@
 /* RECURRENCES. */
 
 static void plis_(int *nf, int *nb, double *x, int *
-		  ix, double *xl, double *xu, double *gf, double *s, 
-		  double *xo, double *go, double *uo, double *vo, 
+		  ix, double *xl, double *xu, double *gf, double *s,
+		  double *xo, double *go, double *uo, double *vo,
 		  double *xmax, double *tolx, double *tolf, double *
 		  tolb, double *tolg, nlopt_stopping *stop,
-		  double *minf_est, double *gmax, 
+		  double *minf_est, double *gmax,
 		  double *f, int *mit, int *mfv, int *iest, int *mf,
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
-    (void) tolb;
-
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -146,6 +144,8 @@ static void plis_(int *nf, int *nb, double *x, int *
     double snorm;
     int mtesx, ntesx;
     ps1l01_state state;
+
+    (void) tolb;
 
 /*     INITIATION */
 
@@ -263,8 +263,8 @@ static void plis_(int *nf, int *nb, double *x, int *
     if (nlopt_stop_time(stop)) { *iterm = 100; goto L11190; }
 L11120:
     luksan_pytrcg__(nf, nf, &ix[1], &gf[1], &umax, gmax, &kbf, &iold);
-    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg, 
-	    &kd, &stat_1->nit, &kit, mit, &stat_1->nfg, &mfg, 
+    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg,
+	    &kd, &stat_1->nit, &kit, mit, &stat_1->nfg, &mfg,
 	    &ntesx, &mtesx, &ntesf, &mtesf, &ites, &ires1, &ires2, &irest, &
 	    iters, iterm);
     if (*iterm != 0) {
@@ -378,7 +378,7 @@ L12620:
 	goto L11175;
     }
 L11170:
-    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin, 
+    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin,
 	    &rmax, &tols, &tolp, &par1, &par2, &kd, &ld, &stat_1->nit, &kit, &
 	    nred, &mred, &maxst, iest, &inits, &iters, &kters, &mes,
 		    &isys, &state);
@@ -445,9 +445,9 @@ nlopt_result luksan_plis(int n, nlopt_func f, void *f_data,
      }
 
  retry_alloc:
-     work = (double*) malloc(sizeof(double) * (n * 4 + MAX2(n,n*mf)*2 + 
+     work = (double*) malloc(sizeof(double) * (n * 4 + MAX2(n,n*mf)*2 +
 					       MAX2(n,mf)*2));
-     if (!work) { 
+     if (!work) {
 	  if (mf > 0) {
 	       mf = 0; /* allocate minimal memory */
 	       goto retry_alloc;
@@ -456,7 +456,7 @@ nlopt_result luksan_plis(int n, nlopt_func f, void *f_data,
 	  return NLOPT_OUT_OF_MEMORY;
      }
 
-     xl = work; xu = xl + n; gf = xu + n; s = gf + n; 
+     xl = work; xu = xl + n; gf = xu + n; s = gf + n;
      xo = s + n; go = xo + MAX2(n,n*mf);
      uo = go + MAX2(n,n*mf); vo = uo + MAX2(n,mf);
 
@@ -474,7 +474,7 @@ nlopt_result luksan_plis(int n, nlopt_func f, void *f_data,
 	arrays to zero by default? */
      memset(xo, 0, sizeof(double) * MAX2(n,n*mf));
 
-     plis_(&n, &nb, x, ix, xl, xu, 
+     plis_(&n, &nb, x, ix, xl, xu,
 	   gf, s, xo, go, uo, vo,
 	   &xmax,
 

--- a/src/algs/luksan/pnet.c
+++ b/src/algs/luksan/pnet.c
@@ -126,19 +126,17 @@ static double c_b7 = 0.;
 /* RECURRENCES. */
 
 static void pnet_(int *nf, int *nb, double *x, int *
-		  ix, double *xl, double *xu, double *gf, double *gn, 
-		  double *s, double *xo, double *go, double *xs, 
-		  double *gs, double *xm, double *gm, double *u1, 
-		  double *u2, double *xmax, double *tolx, double *tolf, 
+		  ix, double *xl, double *xu, double *gf, double *gn,
+		  double *s, double *xo, double *go, double *xs,
+		  double *gs, double *xm, double *gm, double *u1,
+		  double *u2, double *xmax, double *tolx, double *tolf,
 		  double *tolb, double *tolg, nlopt_stopping *stop,
 		  double *minf_est, double *
-		  gmax, double *f, int *mit, int *mfv, int *mfg, 
-		  int *iest, int *mos1, int *mos2, int *mf, 
+		  gmax, double *f, int *mit, int *mfv, int *mfg,
+		  int *iest, int *mos1, int *mos2, int *mf,
 		  int *iterm, stat_common *stat_1,
 		  nlopt_func objgrad, void *objgrad_data)
 {
-	(void) tolb;
-
     /* System generated locals */
     int i__1;
     double d__1, d__2;
@@ -174,6 +172,8 @@ static void pnet_(int *nf, int *nb, double *x, int *
     double snorm;
     int mtesx, ntesx;
     ps1l01_state state;
+
+	(void) tolb;
 
 /*     INITIATION */
 
@@ -305,7 +305,7 @@ static void pnet_(int *nf, int *nb, double *x, int *
 L11020:
     luksan_pytrcg__(nf, nf, &ix[1], &gf[1], &umax, gmax, &kbf, &iold);
     luksan_mxvcop__(nf, &gf[1], &gn[1]);
-    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg, 
+    luksan_pyfut1__(nf, f, &fo, &umax, gmax, xstop, stop, tolg,
 	    &kd, &stat_1->nit, &kit, mit, &stat_1->nfg, mfg, &
 	    ntesx, &mtesx, &ntesf, &mtesf, &ites, &ires1, &ires2, &irest, &
 	    iters, iterm);
@@ -514,7 +514,7 @@ L12560:
 	goto L11075;
     }
 L11060:
-    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin, 
+    luksan_ps1l01__(&r__, &rp, f, &fo, &fp, &p, &po, &pp, minf_est, &maxf, &rmin,
 	    &rmax, &tols, &tolp, &par1, &par2, &kd, &ld, &stat_1->nit, &kit, &
 	    nred, &mred, &maxst, iest, &inits, &iters, &kters, &mes,
 		    &isys, &state);
@@ -567,7 +567,7 @@ L11080:
 nlopt_result luksan_pnet(int n, nlopt_func f, void *f_data,
 			 const double *lb, const double *ub, /* bounds */
 			 double *x, /* in: initial guess, out: minimizer */
-			 double *minf, 
+			 double *minf,
 			 nlopt_stopping *stop,
 			 int mf, /* subspace dimension (0 for default) */
 			 int mos1, int mos2) /* 1 or 2 */
@@ -594,9 +594,9 @@ nlopt_result luksan_pnet(int n, nlopt_func f, void *f_data,
      }
 
  retry_alloc:
-     work = (double*) malloc(sizeof(double) * (n * 9 + MAX2(n,n*mf)*2 + 
+     work = (double*) malloc(sizeof(double) * (n * 9 + MAX2(n,n*mf)*2 +
 					       MAX2(n,mf)*2));
-     if (!work) { 
+     if (!work) {
 	  if (mf > 0) {
 	       mf = 0; /* allocate minimal memory */
 	       goto retry_alloc;
@@ -606,7 +606,7 @@ nlopt_result luksan_pnet(int n, nlopt_func f, void *f_data,
      }
 
      xl = work; xu = xl + n;
-     gf = xu + n; gn = gf + n; s = gn + n; 
+     gf = xu + n; gn = gf + n; s = gn + n;
      xo = s + n; go = xo + n; xs = go + n; gs = xs + n;
      xm = gs + n; gm = xm + MAX2(n*mf,n);
      u1 = gm + MAX2(n*mf,n); u2 = u1 + MAX2(n,mf);
@@ -625,7 +625,7 @@ nlopt_result luksan_pnet(int n, nlopt_func f, void *f_data,
 	arrays to zero by default? */
      memset(xo, 0, sizeof(double) * MAX2(n,n*mf));
 
-     pnet_(&n, &nb, x, ix, xl, xu, 
+     pnet_(&n, &nb, x, ix, xl, xu,
 	   gf, gn, s, xo, go, xs, gs, xm, gm, u1, u2,
 	   &xmax,
 

--- a/src/algs/luksan/pssubs.c
+++ b/src/algs/luksan/pssubs.c
@@ -22,7 +22,7 @@
 *  II  KBF  SPECIFICATION OF SIMPLE BOUNDS. KBF=0-NO SIMPLE BOUNDS.
 *         KBF=1-ONE SIDED SIMPLE BOUNDS. KBF=2=TWO SIDED SIMPLE BOUNDS.
 */
-void luksan_pcbs04__(int *nf, double *x, int *ix, 
+void luksan_pcbs04__(int *nf, double *x, int *ix,
 	double *xl, double *xu, double *eps9, int *kbf)
 {
     /* System generated locals */
@@ -88,8 +88,8 @@ void luksan_pcbs04__(int *nf, double *x, int *ix,
 /* METHOD : */
 /* EXTRAPOLATION OR INTERPOLATION WITH STANDARD MODEL FUNCTIONS. */
 
-void luksan_pnint1__(double *rl, double *ru, double *fl, 
-	double *fu, double *pl, double *pu, double *r__, 
+void luksan_pnint1__(double *rl, double *ru, double *fl,
+	double *fu, double *pl, double *pu, double *r__,
 	int *mode, int *mtyp, int *merr)
 {
     /* System generated locals */
@@ -279,13 +279,13 @@ L1:
 * SAFEGUARDED EXTRAPOLATION AND INTERPOLATION WITH STANDARD TERMINATION
 * CRITERIA.
 */
-void luksan_ps1l01__(double *r__, double *rp, 
-	double *f, double *fo, double *fp, double *p, 
-	double *po, double *pp, double *minf, double *maxf, 
+void luksan_ps1l01__(double *r__, double *rp,
+	double *f, double *fo, double *fp, double *p,
+	double *po, double *pp, double *minf, double *maxf,
 	double *rmin, double *rmax, double *tols, double *
-	tolp, double *par1, double *par2, int *kd, int *ld, 
+	tolp, double *par1, double *par2, int *kd, int *ld,
 	int *nit, int *kit, int *nred, int *mred, int *
-	maxst, int *iest, int *inits, int *iters, int *kters, 
+	maxst, int *iest, int *inits, int *iters, int *kters,
 	int *mes, int *isys, ps1l01_state *state)
 {
     /* System generated locals */
@@ -398,12 +398,12 @@ L3:
 	m2 = FALSE_;
 	m3 = l3;
 	if (mes3 >= 1) {
-	    m1 = fabs(*p) <= fabs(*po) * .01 && *fo - *f >= fabs(*fo) * 
+	    m1 = fabs(*p) <= fabs(*po) * .01 && *fo - *f >= fabs(*fo) *
 		    9.9999999999999994e-12;
 	    l3 = l3 || m1;
 	}
 	if (mes3 >= 2) {
-	    m2 = fabs(*p) <= fabs(*po) * .5 && (d__1 = *fo - *f, fabs(d__1)) <= 
+	    m2 = fabs(*p) <= fabs(*po) * .5 && (d__1 = *fo - *f, fabs(d__1)) <=
 		    fabs(*fo) * 2.0000000000000001e-13;
 	    l3 = l3 || m2;
 	}
@@ -513,13 +513,11 @@ L4:
 * METHOD :
 * SHIFTED BFGS METHOD IN THE PRODUCT FORM.
 */
-void luksan_pulsp3__(int *n, int *m, int *mf, 
-	double *xm, double *gr, double *xo, double *go, 
-	double *r__, double *po, double *sig, int *iterh, 
+void luksan_pulsp3__(int *n, int *m, int *mf,
+	double *xm, double *gr, double *xo, double *go,
+	double *r__, double *po, double *sig, int *iterh,
 	int *met3)
 {
-    (void) r__; (void) po;
-
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
@@ -527,6 +525,8 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
 
     /* Local variables */
     double a, b, aa, bb, ah, den, par, pom;
+
+    (void) r__; (void) po;
 
     /* Parameter adjustments */
     --go;
@@ -559,14 +559,14 @@ void luksan_pulsp3__(int *n, int *m, int *mf,
 	    d__1 = 0., d__2 = 1. - aa / a;
 /* Computing MAX */
 	    d__3 = 0., d__4 = 1. - b * b / (den * ah);
-	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) * 
+	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) *
 		    pom;
 	} else {
 /* Computing MAX */
 	    d__1 = 0., d__2 = *sig * ah / a;
 /* Computing MAX */
 	    d__3 = 0., d__4 = 1. - b * b / (den * ah);
-	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) * 
+	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) *
 		    pom;
 	}
 /* Computing MAX */
@@ -642,14 +642,12 @@ L22:
 * METHOD :
 * RANK-ONE LIMITED-STORAGE VARIABLE-METRIC METHOD IN THE PRODUCT FORM.
 */
-void luksan_pulvp3__(int *n, int *m, double *xm, 
-	double *xr, double *gr, double *s, double *so, 
-	double *xo, double *go, double *r__, double *po, 
-	double *sig, int *iterh, int *met2, int *met3, 
+void luksan_pulvp3__(int *n, int *m, double *xm,
+	double *xr, double *gr, double *s, double *so,
+	double *xo, double *go, double *r__, double *po,
+	double *sig, int *iterh, int *met2, int *met3,
 	int *met5)
 {
-    (void) po;
-
     /* System generated locals */
     double d__1, d__2, d__3, d__4;
 
@@ -657,6 +655,8 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
 
     /* Local variables */
     double a, b, aa, bb, cc, ah, den, par, pom, zet;
+
+    (void) po;
 
     /* Parameter adjustments */
     --go;
@@ -703,14 +703,14 @@ void luksan_pulvp3__(int *n, int *m, double *xm,
 	    d__1 = 0., d__2 = 1. - aa / a;
 /* Computing MAX */
 	    d__3 = 0., d__4 = 1. - b * b / (den * ah);
-	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) * 
+	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) *
 		    pom;
 	} else {
 /* Computing MAX */
 	    d__1 = 0., d__2 = *sig * ah / a;
 /* Computing MAX */
 	    d__3 = 0., d__4 = 1. - b * b / (den * ah);
-	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) * 
+	    *sig = sqrt((MAX2(d__1,d__2))) / (sqrt((MAX2(d__3,d__4))) + 1.) *
 		    pom;
 	}
 /* Computing MAX */
@@ -787,7 +787,7 @@ L22:
 *  RI  XU(NF)  VECTOR CONTAINING UPPER BOUNDS FOR VARIABLES.
 *  IO  INEW  NUMBER OF ACTIVE CONSTRAINTS.
 */
-void luksan_pyadc0__(int *nf, int *n, double *x, 
+void luksan_pyadc0__(int *nf, int *n, double *x,
 	int *ix, double *xl, double *xu, int *inew)
 {
     /* System generated locals */
@@ -882,13 +882,13 @@ void luksan_pyadc0__(int *nf, int *n, double *x,
 *         ITERATIONS. ITERM=12-TERMINATION AFTER MAXIMUM NUMBER OF
 *         COMPUTED FUNCTION VALUES.
 */
-void luksan_pyfut1__(int *n, double *f, double *fo, double *umax, 
+void luksan_pyfut1__(int *n, double *f, double *fo, double *umax,
 		     double *gmax, int xstop, /* double *dmax__,  */
 		     const nlopt_stopping *stop,
-		     double *tolg, int *kd, int *nit, int *kit, int *mit, 
-		     int *nfg, int *mfg, int *ntesx, 
-	int *mtesx, int *ntesf, int *mtesf, int *ites, 
-	int *ires1, int *ires2, int *irest, int *iters, 
+		     double *tolg, int *kd, int *nit, int *kit, int *mit,
+		     int *nfg, int *mfg, int *ntesx,
+	int *mtesx, int *ntesf, int *mtesf, int *ites,
+	int *ires1, int *ires2, int *irest, int *iters,
 	int *iterm)
 {
     /* System generated locals */
@@ -985,8 +985,8 @@ L1:
 *  II  IOLD  NUMBER OF REMOVED CONSTRAINTS.
 *  IU  IREST  RESTART INDICATOR.
 */
-void luksan_pyrmc0__(int *nf, int *n, int *ix, 
-	double *g, double *eps8, double *umax, double *gmax, 
+void luksan_pyrmc0__(int *nf, int *n, int *ix,
+	double *g, double *eps8, double *umax, double *gmax,
 	double *rmax, int *iold, int *irest)
 {
     /* System generated locals */
@@ -1061,9 +1061,9 @@ L2:
 *  S   MXVSAV  DIFFERENCE OF TWO VECTORS WITH COPYING AND SAVING THE
 *         SUBSTRACTED ONE.
 */
-void luksan_pytrcd__(int *nf, double *x, int *ix, 
-	double *xo, double *g, double *go, double *r__, 
-	double *f, double *fo, double *p, double *po, 
+void luksan_pytrcd__(int *nf, double *x, int *ix,
+	double *xo, double *g, double *go, double *r__,
+	double *f, double *fo, double *p, double *po,
 	double *dmax__, int *kbf, int *kd, int *ld, int *
 	iters)
 {
@@ -1135,8 +1135,8 @@ L1:
 * SUBPROGRAMS USED :
 *  RF  MXVMAX  L-INFINITY NORM OF A VECTOR.
 */
-void luksan_pytrcg__(int *nf, int *n, int *ix, 
-	double *g, double *umax, double *gmax, int *kbf, 
+void luksan_pytrcg__(int *nf, int *n, int *ix,
+	double *g, double *umax, double *gmax, int *kbf,
 	int *iold)
 {
     /* System generated locals */
@@ -1212,10 +1212,10 @@ void luksan_pytrcg__(int *nf, int *n, int *ix,
 * SUBPROGRAMS USED :
 *  S   MXVCOP  COPYING OF A VECTOR.
 */
-void luksan_pytrcs__(int *nf, double *x, int *ix, 
-	double *xo, double *xl, double *xu, double *g, 
-	double *go, double *s, double *ro, double *fp, 
-	double *fo, double *f, double *po, double *p, 
+void luksan_pytrcs__(int *nf, double *x, int *ix,
+	double *xo, double *xl, double *xu, double *g,
+	double *go, double *s, double *ro, double *fp,
+	double *fo, double *f, double *po, double *p,
 	double *rmax, double *eta9, int *kbf)
 {
     /* System generated locals */

--- a/src/algs/luksan/pssubs.c
+++ b/src/algs/luksan/pssubs.c
@@ -1,5 +1,6 @@
 #include <math.h>
 #include "luksan.h"
+#include "nlopt-util.h"
 
 #define FALSE_ 0
 #define MAX2(a,b) ((a) > (b) ? (a) : (b))

--- a/src/api/options.c
+++ b/src/api/options.c
@@ -312,7 +312,7 @@ nlopt_result NLOPT_STDCALL nlopt_set_lower_bound(nlopt_opt opt, int i, double lb
 {
     nlopt_unset_errmsg(opt);
     if (opt) {
-        if (i < 0 || i >= opt->n)
+        if (i < 0 || i >= (int) opt->n)
             return ERR(NLOPT_INVALID_ARGS, opt, "invalid bound index");
         opt->lb[i] = lb;
         if (opt->lb[i] < opt->ub[i] && nlopt_istiny(opt->ub[i] - opt->lb[i]))
@@ -366,7 +366,7 @@ nlopt_result NLOPT_STDCALL nlopt_set_upper_bound(nlopt_opt opt, int i, double ub
 {
     nlopt_unset_errmsg(opt);
     if (opt) {
-        if (i < 0 || i >= opt->n)
+        if (i < 0 || i >= (int) opt->n)
             return ERR(NLOPT_INVALID_ARGS, opt, "invalid bound index");
         opt->ub[i] = ub;
         if (opt->lb[i] < opt->ub[i] && nlopt_istiny(opt->ub[i] - opt->lb[i]))

--- a/src/util/nlopt-util.h
+++ b/src/util/nlopt-util.h
@@ -39,7 +39,7 @@
 #ifndef HAVE_COPYSIGN
    /* not quite right for y == -0, but good enough for us */
 #  define copysign(x, y) ((y) < 0 ? -fabs(x) : fabs(x))
-#elif __STDC_VERSION__ < 199901
+#elif __STDC_VERSION__ < 199901 && !defined(__cplusplus)
 extern double copysign(double x, double y); /* may not be declared in C89 */
 #endif
 

--- a/src/util/nlopt-util.h
+++ b/src/util/nlopt-util.h
@@ -7,17 +7,17 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #ifndef NLOPT_UTIL_H
@@ -39,6 +39,8 @@
 #ifndef HAVE_COPYSIGN
    /* not quite right for y == -0, but good enough for us */
 #  define copysign(x, y) ((y) < 0 ? -fabs(x) : fabs(x))
+#elif __STDC_VERSION__ < 199901
+extern double copysign(double x, double y); /* may not be declared in C89 */
 #endif
 
 #ifdef __cplusplus

--- a/src/util/qsort_r.c
+++ b/src/util/qsort_r.c
@@ -179,6 +179,9 @@ void nlopt_qsort_r(void *base_, size_t nmemb, size_t size, void *thunk, cmp_t* c
 #if defined(HAVE_QSORT_R) && (defined(__APPLE__) || defined(__FreeBSD__))
     qsort_r(base_, nmemb, size, thunk, compar);
 #elif defined(HAVE_QSORT_R) && defined(__linux__)
+    extern void qsort_r(void *base, size_t nmemb, size_t size,
+                        int (*compar)(const void *, const void *, void *),
+                        void *arg);
     qsort_wrapper wrapper;
     wrapper.compar = compar;
     wrapper.thunk = thunk;

--- a/test/testopt.c
+++ b/test/testopt.c
@@ -7,17 +7,17 @@
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject to
  * the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #include <stdlib.h>
@@ -290,16 +290,20 @@ static void usage(FILE * f)
             " -a <n> : use optimization algorithm <n>\n"
             " -o <n> : use objective function <n>\n"
             " -0 <x> : starting guess within <x> + (1+<x>) * optimum\n"
-            " -b <dim0,dim1,...>: eliminate given dims by equating bounds\n"
+            " -b <dim0,dim1,...>: eliminate given dims by equating bounds\n");
+    fprintf(f,
             "     -c : starting guess at center of cell\n"
             "     -C : put optimum outside of bound constraints\n"
             " -e <n> : use at most <n> evals (default: %d, 0 to disable)\n"
             " -t <t> : use at most <t> seconds (default: disabled)\n"
             " -x <t> : relative tolerance <t> on x (default: disabled)\n"
-            " -X <t> : absolute tolerance <t> on x (default: disabled)\n"
+            " -X <t> : absolute tolerance <t> on x (default: disabled)\n", maxeval);
+    fprintf(f,
             " -f <t> : relative tolerance <t> on f (default: disabled)\n"
             " -F <t> : absolute tolerance <t> on f (default: disabled)\n"
-            " -m <m> : stop when minf+<m> is reached (default: disabled)\n" " -i <n> : iterate optimization <n> times (default: 1)\n" " -r <s> : use random seed <s> for starting guesses\n", maxeval);
+            " -m <m> : stop when minf+<m> is reached (default: disabled)\n"
+            " -i <n> : iterate optimization <n> times (default: 1)\n"
+            " -r <s> : use random seed <s> for starting guesses\n");
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Fixes #259, adds `-std=c89 -pedantic -Werror` to compilation flags on Travis to catch future C89 errors.