### PR TITLE
add argument checks to nlopt_get_xtol_abs

### DIFF
--- a/src/api/options.c
+++ b/src/api/options.c
@@ -624,8 +624,12 @@ nlopt_result NLOPT_STDCALL nlopt_set_xtol_abs1(nlopt_opt opt, double xtol_abs)
 
 nlopt_result NLOPT_STDCALL nlopt_get_xtol_abs(const nlopt_opt opt, double *xtol_abs)
 {
-    memcpy(xtol_abs, opt->xtol_abs, opt->n * sizeof(double));
-    return NLOPT_SUCCESS;
+    nlopt_unset_errmsg(opt);
+    if (opt && (opt->n == 0 || xtol_abs)) {
+        memcpy(xtol_abs, opt->xtol_abs, opt->n * sizeof(double));
+        return NLOPT_SUCCESS;
+    }
+    return NLOPT_INVALID_ARGS;
 }
 
 GETSET(maxeval, int, maxeval)


### PR DESCRIPTION
Similar `nlopt_get_*` functions in `options.c` always check for
`(opt && (opt->n == 0 || argument))`, requiring a valid `nlopt * opt`
and only allowing a null argument when the optimizer is "empty".

`nlopt_get_xtol_abs` seems to have been left out (13e0f277).