### PR TITLE
rm obsolete #ifdef NLOPT_UTIL_H in stogo code

### DIFF
--- a/src/algs/stogo/global.h
+++ b/src/algs/stogo/global.h
@@ -26,12 +26,7 @@ typedef objgrad* Pobjgrad ;
 
 class GlobalParams {
 public:
-#ifdef NLOPT_UTIL_H
   nlopt_stopping *stop;
-#else
-  double maxtime;
-  long int maxeval;
-#endif
   double eps_cl, mu, rshift;
   int det_pnts, rnd_pnts;
 };
@@ -57,9 +52,9 @@ public:
        }
        return 0.0;
   }
-				   
+
   Global(RTBox, Pobj, Pgrad, GlobalParams);
-  
+
   virtual ~Global(){};
 
 //  Global& operator=(const Global &);

--- a/src/algs/stogo/local.h
+++ b/src/algs/stogo/local.h
@@ -20,10 +20,6 @@ const int max_iter=50 ;            // Max iterations = max_iter*dim. of problem
 
 extern double MacEpsilon ;   //  min {x >= 0 : 1 + x > 1}
 
-int local(Trial &, TBox &, TBox &, double, double*, Global&, int, RCRVector
-#ifdef NLOPT_UTIL_H
-	  , nlopt_stopping *stop
-#endif
-     );
+int local(Trial &, TBox &, TBox &, double, double*, Global&, int, RCRVector, nlopt_stopping *stop);
 
 #endif


### PR DESCRIPTION
As mentioned in #267, these are unnecessary and clutter up the code.   (This PR doesn't change what code is actually executed, it just removes dead code.)