### PR TITLE
Set matlab extension linker language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,7 @@ if (NLOPT_OCTAVE)
 endif ()
 
 if (NLOPT_MATLAB)
-  find_package (Matlab COMPONENTS MX_LIBRARY)
+  find_package (Matlab COMPONENTS MX_LIBRARY MAIN_PROGRAM)
 endif ()
 
 if (OCTAVE_FOUND OR Matlab_FOUND)

--- a/doc/docs/NLopt_Installation.md
+++ b/doc/docs/NLopt_Installation.md
@@ -99,6 +99,12 @@ cmake -DINSTALL_MEX_DIR=dir ..
 
 to install the Matlab plugins in directory *dir*. In this case, however, when you run Matlab you will either need to run in the *dir* directory or explicitly add *dir* to your Matlab path (see the Matlab `path` command).
 
+Matlab's standard C++ library might be incompatible with the one used by your compiler, in that case you can try to disable the C++ algorithms:
+
+```sh
+cmake -DNLOPT_CXX=OFF ..
+```
+
 ### Octave
 
 For the Octave plugins to be installed, you need to have the Octave `mkoctfile` program in your PATH. `mkoctfile` is Octave's equivalent of `mex`. If you are using a GNU/Linux system, and you installed Octave using one of the precompiled packages for your distribution, then you probably need to install a *separate package* to get `mkoctfile`. For example, on Debian you need to install the `octave-headers` package, and on Redhat you need the `octave-devel` package.

--- a/src/octave/CMakeLists.txt
+++ b/src/octave/CMakeLists.txt
@@ -6,6 +6,9 @@ if (Matlab_FOUND AND Matlab_MX_LIBRARY)
   cmake_minimum_required (VERSION 3.3) # for the matlab_add_mex macro
 
   matlab_add_mex (NAME nlopt_optimize-mex SRC nlopt_optimize-mex.c OUTPUT_NAME nlopt_optimize LINK_TO ${nlopt_lib})
+  if (NLOPT_CXX)
+    set_target_properties (nlopt_optimize-mex PROPERTIES LINKER_LANGUAGE CXX)
+  endif ()
 
   if (NOT DEFINED INSTALL_MEX_DIR)
     set (INSTALL_MEX_DIR ${INSTALL_LIB_DIR}/matlab)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,10 @@ if (OCTAVE_FOUND)
   add_test (NAME test_octave COMMAND ${OCTAVE_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/t_octave.m ${PROJECT_SOURCE_DIR}/src/octave ${PROJECT_BINARY_DIR}/src/octave)
 endif ()
 
+if (MATLAB_FOUND)
+  add_test (NAME test_matlab COMMAND ${Matlab_MAIN_PROGRAM} -nodesktop -nosplash  -r "addpath('${PROJECT_SOURCE_DIR}/src/octave'); addpath('${PROJECT_BINARY_DIR}/src/octave'); try; run('${CMAKE_CURRENT_SOURCE_DIR}/t_matlab.m'); catch; exit(1); end; quit")
+endif ()
+
 if (GUILE_FOUND AND ((SWIG_FOUND AND SWIG_VERSION VERSION_GREATER 2.0.9) OR (EXISTS ${PROJECT_SOURCE_DIR}/src/swig/nlopt-guile.cpp)))
   set (GUILECHECK_ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src/swig"
                               "GUILE_LOAD_PATH=${PROJECT_BINARY_DIR}/src/swig"

--- a/test/myconstraint.m
+++ b/test/myconstraint.m
@@ -1,0 +1,6 @@
+function [val, gradient] = myconstraint(x,a,b)
+    val = (a*x(1) + b)^3 - x(2);
+    if (nargout > 1)
+        gradient = [3*a*(a*x(1) + b)^2, -1];
+    end
+end

--- a/test/myfunc.m
+++ b/test/myfunc.m
@@ -1,0 +1,6 @@
+function [val, gradient] = myfunc(x)
+    val = sqrt(x(2));
+    if (nargout > 1)
+        gradient = [0, 0.5 / val];
+    end
+end

--- a/test/t_matlab.m
+++ b/test/t_matlab.m
@@ -1,0 +1,9 @@
+
+opt.algorithm = NLOPT_LD_MMA
+%  opt.algorithm = NLOPT_LN_COBYLA
+opt.lower_bounds = [-inf, 0]
+opt.min_objective = @myfunc
+opt.fc = { (@(x) myconstraint(x,2,0)), (@(x) myconstraint(x,-1,1)) }
+opt.fc_tol = [1e-8, 1e-8];
+opt.xtol_rel = 1e-4
+[xopt, fmin, retcode] = nlopt_optimize(opt, [1.234 5.678])


### PR DESCRIPTION
Also matlab's c++ library might be older and incompatible with the compiler's one,
so mention in the doc the possible workaround.

Added a test.