### PR TITLE
Correct compilation error with C++17 (unary functions removed)

### DIFF
--- a/src/algs/stogo/tools.h
+++ b/src/algs/stogo/tools.h
@@ -36,7 +36,11 @@ public:
   friend ostream & operator << (ostream &, RCTrial) ;
 };
 
+#if __cplusplus < 201103L
 class TrialGT : public unary_function<Trial, bool>
+#else
+class TrialGT
+#endif
 // Predicate for Trial (needed for remove_if)
 {
 public:


### PR DESCRIPTION
When compiling the current master on Windows with Visual studio 2017 or higher with the C++17 standard, compilation errors show up due to unary_function being removed from the C++ standard from that point on.

The correction being very simple (just remove the inheritance from unary_function from C++ standard C++11), I propose here a little patch to handle this.

Tell me what you think