### PR TITLE
Add usage of _MSVC_LANG for windows C++ standard check

### DIFF
--- a/src/algs/stogo/tools.h
+++ b/src/algs/stogo/tools.h
@@ -36,7 +36,7 @@ public:
   friend ostream & operator << (ostream &, RCTrial) ;
 };
 
-#if (!defined(_WIN32) && (__cplusplus < 201103L)) || (defined(_WIN32) && (_MSVC_LANG < 201103L))
+#if (!defined(_MSC_VER) && (__cplusplus < 201103L)) || (defined(_MSC_VER) && (_MSVC_LANG < 201103L))
 class TrialGT : public unary_function<Trial, bool>
 #else
 class TrialGT

--- a/src/algs/stogo/tools.h
+++ b/src/algs/stogo/tools.h
@@ -36,7 +36,7 @@ public:
   friend ostream & operator << (ostream &, RCTrial) ;
 };
 
-#if __cplusplus < 201103L
+#if (!defined(_WIN32) && (__cplusplus < 201103L)) || (defined(_WIN32) && (_MSVC_LANG < 201103L))
 class TrialGT : public unary_function<Trial, bool>
 #else
 class TrialGT


### PR DESCRIPTION
Following discussion on PR #294 , here is an improvement that should work for all compilers (windows or not). Sorry about the error in the first place