### PR TITLE
MEX library symbols visibility set to default

### DIFF
--- a/src/octave/CMakeLists.txt
+++ b/src/octave/CMakeLists.txt
@@ -6,7 +6,12 @@ if (Matlab_FOUND AND Matlab_MX_LIBRARY)
   cmake_minimum_required (VERSION 3.3) # for the matlab_add_mex macro
 
   matlab_add_mex (NAME nlopt_optimize-mex SRC nlopt_optimize-mex.c OUTPUT_NAME nlopt_optimize LINK_TO ${nlopt_lib})
-  set_target_properties(nlopt_optimize-mex PROPERTIES COMPILE_FLAGS "-fvisibility=default")
+  if (CMAKE_VERSION VERSION_LESS 3.14.0)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+      message("Forcing mexFunction visibility to default")
+      set_target_properties(nlopt_optimize-mex PROPERTIES COMPILE_FLAGS "-fvisibility=default")
+    endif()
+  endif()
   
   if (NLOPT_CXX)
     set_target_properties (nlopt_optimize-mex PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/octave/CMakeLists.txt
+++ b/src/octave/CMakeLists.txt
@@ -6,6 +6,8 @@ if (Matlab_FOUND AND Matlab_MX_LIBRARY)
   cmake_minimum_required (VERSION 3.3) # for the matlab_add_mex macro
 
   matlab_add_mex (NAME nlopt_optimize-mex SRC nlopt_optimize-mex.c OUTPUT_NAME nlopt_optimize LINK_TO ${nlopt_lib})
+  set_target_properties(nlopt_optimize-mex PROPERTIES COMPILE_FLAGS "-fvisibility=default")
+  
   if (NLOPT_CXX)
     set_target_properties (nlopt_optimize-mex PROPERTIES LINKER_LANGUAGE CXX)
   endif ()


### PR DESCRIPTION
By default, the mexFunctions seems to be hidden in the newer Matlab version, this fix force the compiler to keep the symbols visible.