### PR TITLE
Show `opt.add_equality_mconstraint` as an option

### DIFF
--- a/doc/docs/NLopt_Python_Reference.md
+++ b/doc/docs/NLopt_Python_Reference.md
@@ -149,7 +149,7 @@ Just as for [nonlinear constraints in C](NLopt_Reference#Vector-valued_constrain
 
 ```
 opt.add_inequality_mconstraint(c, tol)
-opt.add_inequality_mconstraint(c, tol)
+opt.add_equality_mconstraint(c, tol)
 ```
 
 


### PR DESCRIPTION
Vector-valued constraints section listed `opt.add_inequality_mconstraint` twice, when it looks like it meant to list both of `opt.add_inequality_mconstraint` and `opt.add_equality_mconstraint`.