### PR TITLE
avoid linker conflicts for nlopt-getopt.c + libc with getopt

### DIFF
--- a/nlopt_config.h.in
+++ b/nlopt_config.h.in
@@ -37,6 +37,9 @@
 /* Define to 1 if you have the <getopt.h> header file. */
 #cmakedefine HAVE_GETOPT_H
 
+/* Define to 1 if you have the getopt function in your standard libary. */
+#cmakedefine HAVE_GETOPT
+
 /* Define to 1 if you have the `getpid' function. */
 #cmakedefine HAVE_GETPID
 

--- a/src/util/nlopt-getopt.h
+++ b/src/util/nlopt-getopt.h
@@ -34,6 +34,14 @@
 #ifndef NLOPT_GETOPT_H
 #define NLOPT_GETOPT_H
 
+/* avoid linker conflicts if we use nlopt-getopt.c with a libc that has getopt */
+#define opterr nlopt_opterr
+#define optind nlopt_optind
+#define optopt nlopt_optopt
+#define optreset nlopt_optreset
+#define optarg nlopt_optarg
+#define getopt nlopt_getopt
+
 #ifdef  __cplusplus
 extern "C" {
 #endif

--- a/test/testopt.c
+++ b/test/testopt.c
@@ -30,7 +30,7 @@
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif
-#ifdef HAVE_GETOPT_H
+#if defined(HAVE_GETOPT_H) && defined(HAVE_GETOPT)
 #  include <getopt.h>
 #else
 #  include "nlopt-getopt.h"


### PR DESCRIPTION
As discussed in #354.

- [x] Should also make sure HAVE_GETOPT_H is set to false if HAVE_GETOPT is false.