### PR TITLE
Prefix builtin rb_tree symbols to avoid colliding with libc symbols

### DIFF
--- a/src/algs/cdirect/hybrid.c
+++ b/src/algs/cdirect/hybrid.c
@@ -138,7 +138,7 @@ static nlopt_result divide_largest(params *p)
 {
      int L = p->L;
      int n = p->n;
-     rb_node *node = rb_tree_max(&p->rtree); /* just using it as a heap */
+     rb_node *node = nlopt_rb_tree_max(&p->rtree); /* just using it as a heap */
      double minf_start = p->minf;
      double *r = node->k, *rnew = NULL;
      double *x = r + 3, *c = x + n, *w = c + n;
@@ -179,7 +179,7 @@ static nlopt_result divide_largest(params *p)
 	  r[0] = longest(n, w); /* new diameter */
 	  /* r[1] unchanged since still contains local optimum x */
 	  r[2] = p->age--;
-	  node = rb_tree_resort(&p->rtree, node);
+	  node = nlopt_rb_tree_resort(&p->rtree, node);
 
 	  rnew = (double *) malloc(sizeof(double) * L);
 	  if (!rnew) return NLOPT_OUT_OF_MEMORY;
@@ -192,7 +192,7 @@ static nlopt_result divide_largest(params *p)
 	       memcpy(rnew+3, rnew+3+n, sizeof(double) * n); /* x = c */
 	  ret = optimize_rect(rnew, p);
 	  if (ret != NLOPT_SUCCESS) { free(rnew); return ret; }
-	  if (!rb_tree_insert(&p->rtree, rnew)) {
+	  if (!nlopt_rb_tree_insert(&p->rtree, rnew)) {
 	       free(rnew); return NLOPT_OUT_OF_MEMORY;
 	  }
      }
@@ -201,7 +201,7 @@ static nlopt_result divide_largest(params *p)
 	  r[0] = longest(n, w);
 	  /* r[1] unchanged since still contains local optimum x */
 	  r[2] = p->age--;
-	  node = rb_tree_resort(&p->rtree, node);
+	  node = nlopt_rb_tree_resort(&p->rtree, node);
 
 	  for (i = -1; i <= +1; i += 2) {
 	       rnew = (double *) malloc(sizeof(double) * L);
@@ -215,7 +215,7 @@ static nlopt_result divide_largest(params *p)
 		    memcpy(rnew+3, rnew+3+n, sizeof(double) * n); /* x = c */
 	       ret = optimize_rect(rnew, p);
 	       if (ret != NLOPT_SUCCESS) { free(rnew); return ret; }
-	       if (!rb_tree_insert(&p->rtree, rnew)) {
+	       if (!nlopt_rb_tree_insert(&p->rtree, rnew)) {
 		    free(rnew); return NLOPT_OUT_OF_MEMORY;
 	       }
 	  }
@@ -254,7 +254,7 @@ nlopt_result cdirect_hybrid_unscaled(int n, nlopt_func f, void *f_data,
      p.randomized_div = randomized_div;
      p.local_opt = 0;
 
-     rb_tree_init(&p.rtree, cdirect_hyperrect_compare);
+     nlopt_rb_tree_init(&p.rtree, cdirect_hyperrect_compare);
      p.work = (double *) malloc(sizeof(double) * (2*n));
      if (!p.work) goto done;
 
@@ -289,14 +289,14 @@ nlopt_result cdirect_hybrid_unscaled(int n, nlopt_func f, void *f_data,
 
      ret = optimize_rect(rnew, &p);
      if (ret != NLOPT_SUCCESS) { free(rnew); goto done; }
-     if (!rb_tree_insert(&p.rtree, rnew)) { free(rnew); goto done; }
+     if (!nlopt_rb_tree_insert(&p.rtree, rnew)) { free(rnew); goto done; }
 
      do {
 	  ret = divide_largest(&p);
      } while (ret == NLOPT_SUCCESS);
 
  done:
-     rb_tree_destroy_with_keys(&p.rtree);
+     nlopt_rb_tree_destroy_with_keys(&p.rtree);
      free(p.work);
      nlopt_destroy(p.local_opt);
 

--- a/src/algs/crs/crs.c
+++ b/src/algs/crs/crs.c
@@ -124,8 +124,8 @@ static void random_trial(crs_data *d, double *x, rb_node *best)
 
 static nlopt_result crs_trial(crs_data *d)
 {
-     rb_node *best = rb_tree_min(&d->t);
-     rb_node *worst = rb_tree_max(&d->t);
+     rb_node *best = nlopt_rb_tree_min(&d->t);
+     rb_node *worst = nlopt_rb_tree_max(&d->t);
      int mutation = NUM_MUTATION;
      int i, n = d->n;
      random_trial(d, d->p + 1, best);
@@ -151,14 +151,14 @@ static nlopt_result crs_trial(crs_data *d)
 	  }
      } while (1);
      memcpy(worst->k, d->p, sizeof(double) * (n+1));
-     rb_tree_resort(&d->t, worst);
+     nlopt_rb_tree_resort(&d->t, worst);
      return NLOPT_SUCCESS;
 }
 
 static void crs_destroy(crs_data *d)
 {
      nlopt_sobol_destroy(d->s);
-     rb_tree_destroy(&d->t);
+     nlopt_rb_tree_destroy(&d->t);
      free(d->ps);
 }
 
@@ -190,7 +190,7 @@ static nlopt_result crs_init(crs_data *d, int n, const double *x,
      d->ps = (double *) malloc(sizeof(double) * (n + 1) * (d->N + 1));
      if (!d->ps) return NLOPT_OUT_OF_MEMORY;
      d->p = d->ps + d->N * (n+1);
-     rb_tree_init(&d->t, crs_compare);
+     nlopt_rb_tree_init(&d->t, crs_compare);
 
      /* we can either use pseudorandom points, as in the original CRS
 	algorithm, or use a low-discrepancy Sobol' sequence ... I tried
@@ -204,7 +204,7 @@ static nlopt_result crs_init(crs_data *d, int n, const double *x,
      memcpy(d->ps + 1, x, sizeof(double) * n);
      d->ps[0] = f(n, x, NULL, f_data);
      ++ *(stop->nevals_p);
-     if (!rb_tree_insert(&d->t, d->ps)) return NLOPT_OUT_OF_MEMORY;
+     if (!nlopt_rb_tree_insert(&d->t, d->ps)) return NLOPT_OUT_OF_MEMORY;
      if (d->ps[0] < stop->minf_max) return NLOPT_MINF_MAX_REACHED;
      if (nlopt_stop_evals(stop)) return NLOPT_MAXEVAL_REACHED;
      if (nlopt_stop_time(stop)) return NLOPT_MAXTIME_REACHED;
@@ -219,7 +219,7 @@ static nlopt_result crs_init(crs_data *d, int n, const double *x,
 	  }
 	  k[0] = f(n, k + 1, NULL, f_data);
 	  ++ *(stop->nevals_p);
-	  if (!rb_tree_insert(&d->t, k)) return NLOPT_OUT_OF_MEMORY;
+	  if (!nlopt_rb_tree_insert(&d->t, k)) return NLOPT_OUT_OF_MEMORY;
 	  if (k[0] < stop->minf_max) return NLOPT_MINF_MAX_REACHED;
 	  if (nlopt_stop_evals(stop)) return NLOPT_MAXEVAL_REACHED;
 	  if (nlopt_stop_time(stop)) return NLOPT_MAXTIME_REACHED;	  
@@ -243,13 +243,13 @@ nlopt_result crs_minimize(int n, nlopt_func f, void *f_data,
      ret = crs_init(&d, n, x, lb, ub, stop, f, f_data, population, lds);
      if (ret < 0) return ret;
      
-     best = rb_tree_min(&d.t);
+     best = nlopt_rb_tree_min(&d.t);
      *minf = best->k[0];
      memcpy(x, best->k + 1, sizeof(double) * n);
 
      while (ret == NLOPT_SUCCESS) {
 	  if (NLOPT_SUCCESS == (ret = crs_trial(&d))) {
-	       best = rb_tree_min(&d.t);
+	       best = nlopt_rb_tree_min(&d.t);
 	       if (best->k[0] < *minf) {
 		    if (best->k[0] < stop->minf_max)
 			 ret = NLOPT_MINF_MAX_REACHED;

--- a/src/algs/neldermead/nldrmd.c
+++ b/src/algs/neldermead/nldrmd.c
@@ -125,7 +125,7 @@ nlopt_result nldrmd_minimize_(int n, nlopt_func f, void *f_data,
      c = scratch + (n+1)*(n+1);
      xcur = c + n;
 
-     rb_tree_init(&t, simplex_compare);
+     nlopt_rb_tree_init(&t, simplex_compare);
 
      *fdiff = HUGE_VAL;
 
@@ -165,14 +165,14 @@ nlopt_result nldrmd_minimize_(int n, nlopt_func f, void *f_data,
 
  restart:
      for (i = 0; i < n + 1; ++i)
-	  if (!rb_tree_insert(&t, pts + i*(n+1))) {
+	  if (!nlopt_rb_tree_insert(&t, pts + i*(n+1))) {
 	       ret = NLOPT_OUT_OF_MEMORY;
 	       goto done;
 	  }
 
      while (1) {
-	  rb_node *low = rb_tree_min(&t);
-	  rb_node *high = rb_tree_max(&t);
+	  rb_node *low = nlopt_rb_tree_min(&t);
+	  rb_node *high = nlopt_rb_tree_max(&t);
 	  double fl = low->k[0], *xl = low->k + 1;
 	  double fh = high->k[0], *xh = high->k + 1;
 	  double fr;
@@ -242,7 +242,7 @@ nlopt_result nldrmd_minimize_(int n, nlopt_func f, void *f_data,
 		    memcpy(xh, xcur, sizeof(double)*n);
 	       }
 	  }
-	  else if (fr < rb_tree_pred(high)->k[0]) { /* accept new point */
+	  else if (fr < nlopt_rb_tree_pred(high)->k[0]) { /* accept new point */
 	       memcpy(xh, xcur, sizeof(double)*n);
 	       fh = fr;
 	  }
@@ -258,8 +258,8 @@ nlopt_result nldrmd_minimize_(int n, nlopt_func f, void *f_data,
 		    fh = fc;
 	       }
 	       else { /* failed contraction, shrink simplex */
-		    rb_tree_destroy(&t);
-		    rb_tree_init(&t, simplex_compare);
+		    nlopt_rb_tree_destroy(&t);
+		    nlopt_rb_tree_init(&t, simplex_compare);
 		    for (i = 0; i < n+1; ++i) {
 			 double *pt = pts + i * (n+1);
 			 if (pt+1 != xl) {
@@ -276,11 +276,11 @@ nlopt_result nldrmd_minimize_(int n, nlopt_func f, void *f_data,
 	  }
 
 	  high->k[0] = fh;
-	  rb_tree_resort(&t, high);
+	  nlopt_rb_tree_resort(&t, high);
      }
      
 done:
-     rb_tree_destroy(&t);
+     nlopt_rb_tree_destroy(&t);
      return ret;
 }
 

--- a/src/util/redblack.c
+++ b/src/util/redblack.c
@@ -33,7 +33,7 @@ rb_node nil = { &nil, &nil, &nil, 0, BLACK };
 
 #define NIL (&nil)
 
-void rb_tree_init(rb_tree * t, rb_compare compare)
+void nlopt_rb_tree_init(rb_tree * t, rb_compare compare)
 {
     t->compare = compare;
     t->root = NIL;
@@ -49,21 +49,21 @@ static void destroy(rb_node * n)
     }
 }
 
-void rb_tree_destroy(rb_tree * t)
+void nlopt_rb_tree_destroy(rb_tree * t)
 {
     destroy(t->root);
     t->root = NIL;
 }
 
-void rb_tree_destroy_with_keys(rb_tree * t)
+void nlopt_rb_tree_destroy_with_keys(rb_tree * t)
 {
-    rb_node *n = rb_tree_min(t);
+    rb_node *n = nlopt_rb_tree_min(t);
     while (n) {
         free(n->k);
         n->k = NULL;
-        n = rb_tree_succ(n);
+        n = nlopt_rb_tree_succ(n);
     }
-    rb_tree_destroy(t);
+    nlopt_rb_tree_destroy(t);
 }
 
 static void rotate_left(rb_node * p, rb_tree * t)
@@ -166,7 +166,7 @@ static void insert_node(rb_tree * t, rb_node * n)
     }
 }
 
-rb_node *rb_tree_insert(rb_tree * t, rb_key k)
+rb_node *nlopt_rb_tree_insert(rb_tree * t, rb_key k)
 {
     rb_node *n = (rb_node *) malloc(sizeof(rb_node));
     if (!n)
@@ -206,7 +206,7 @@ static int check_node(rb_node * n, int *nblack, rb_tree * t)
     return 1;
 }
 
-int rb_tree_check(rb_tree * t)
+int nlopt_rb_tree_check(rb_tree * t)
 {
     int nblack;
     if (nil.c != BLACK)
@@ -220,7 +220,7 @@ int rb_tree_check(rb_tree * t)
     return check_node(t->root, &nblack, t);
 }
 
-rb_node *rb_tree_find(rb_tree * t, rb_key k)
+rb_node *nlopt_rb_tree_find(rb_tree * t, rb_key k)
 {
     rb_compare compare = t->compare;
     rb_node *p = t->root;
@@ -251,7 +251,7 @@ static rb_node *find_le(rb_node * p, rb_key k, rb_tree * t)
 }
 
 /* find greatest point in t <= k */
-rb_node *rb_tree_find_le(rb_tree * t, rb_key k)
+rb_node *nlopt_rb_tree_find_le(rb_tree * t, rb_key k)
 {
     return find_le(t->root, k, t);
 }
@@ -274,7 +274,7 @@ static rb_node *find_lt(rb_node * p, rb_key k, rb_tree * t)
 }
 
 /* find greatest point in t < k */
-rb_node *rb_tree_find_lt(rb_tree * t, rb_key k)
+rb_node *nlopt_rb_tree_find_lt(rb_tree * t, rb_key k)
 {
     return find_lt(t->root, k, t);
 }
@@ -297,12 +297,12 @@ static rb_node *find_gt(rb_node * p, rb_key k, rb_tree * t)
 }
 
 /* find least point in t > k */
-rb_node *rb_tree_find_gt(rb_tree * t, rb_key k)
+rb_node *nlopt_rb_tree_find_gt(rb_tree * t, rb_key k)
 {
     return find_gt(t->root, k, t);
 }
 
-rb_node *rb_tree_min(rb_tree * t)
+rb_node *nlopt_rb_tree_min(rb_tree * t)
 {
     rb_node *n = t->root;
     while (n != NIL && n->l != NIL)
@@ -310,7 +310,7 @@ rb_node *rb_tree_min(rb_tree * t)
     return (n == NIL ? NULL : n);
 }
 
-rb_node *rb_tree_max(rb_tree * t)
+rb_node *nlopt_rb_tree_max(rb_tree * t)
 {
     rb_node *n = t->root;
     while (n != NIL && n->r != NIL)
@@ -318,7 +318,7 @@ rb_node *rb_tree_max(rb_tree * t)
     return (n == NIL ? NULL : n);
 }
 
-rb_node *rb_tree_succ(rb_node * n)
+rb_node *nlopt_rb_tree_succ(rb_node * n)
 {
     if (!n)
         return NULL;
@@ -337,7 +337,7 @@ rb_node *rb_tree_succ(rb_node * n)
     }
 }
 
-rb_node *rb_tree_pred(rb_node * n)
+rb_node *nlopt_rb_tree_pred(rb_node * n)
 {
     if (!n)
         return NULL;
@@ -356,7 +356,7 @@ rb_node *rb_tree_pred(rb_node * n)
     }
 }
 
-rb_node *rb_tree_remove(rb_tree * t, rb_node * n)
+rb_node *nlopt_rb_tree_remove(rb_tree * t, rb_node * n)
 {
     rb_key k = n->k;
     rb_node *m, *mp;
@@ -434,9 +434,9 @@ rb_node *rb_tree_remove(rb_tree * t, rb_node * n)
     return n;                   /* the node that was deleted may be different from initial n */
 }
 
-rb_node *rb_tree_resort(rb_tree * t, rb_node * n)
+rb_node *nlopt_rb_tree_resort(rb_tree * t, rb_node * n)
 {
-    n = rb_tree_remove(t, n);
+    n = nlopt_rb_tree_remove(t, n);
     insert_node(t, n);
     return n;
 }
@@ -452,7 +452,7 @@ static void shift_keys(rb_node * n, ptrdiff_t kshift)
         shift_keys(n->r, kshift);
 }
 
-void rb_tree_shift_keys(rb_tree * t, ptrdiff_t kshift)
+void nlopt_rb_tree_shift_keys(rb_tree * t, ptrdiff_t kshift)
 {
     if (t->root != NIL)
         shift_keys(t->root, kshift);

--- a/src/util/redblack.h
+++ b/src/util/redblack.h
@@ -48,26 +48,26 @@ extern "C" {
         int N;                  /* number of nodes */
     } rb_tree;
 
-    extern void rb_tree_init(rb_tree * t, rb_compare compare);
-    extern void rb_tree_destroy(rb_tree * t);
-    extern void rb_tree_destroy_with_keys(rb_tree * t);
-    extern rb_node *rb_tree_insert(rb_tree * t, rb_key k);
-    extern int rb_tree_check(rb_tree * t);
-    extern rb_node *rb_tree_find(rb_tree * t, rb_key k);
-    extern rb_node *rb_tree_find_le(rb_tree * t, rb_key k);
-    extern rb_node *rb_tree_find_lt(rb_tree * t, rb_key k);
-    extern rb_node *rb_tree_find_gt(rb_tree * t, rb_key k);
-    extern rb_node *rb_tree_resort(rb_tree * t, rb_node * n);
-    extern rb_node *rb_tree_min(rb_tree * t);
-    extern rb_node *rb_tree_max(rb_tree * t);
-    extern rb_node *rb_tree_succ(rb_node * n);
-    extern rb_node *rb_tree_pred(rb_node * n);
-    extern void rb_tree_shift_keys(rb_tree * t, ptrdiff_t kshift);
+    extern void nlopt_rb_tree_init(rb_tree * t, rb_compare compare);
+    extern void nlopt_rb_tree_destroy(rb_tree * t);
+    extern void nlopt_rb_tree_destroy_with_keys(rb_tree * t);
+    extern rb_node *nlopt_rb_tree_insert(rb_tree * t, rb_key k);
+    extern int nlopt_rb_tree_check(rb_tree * t);
+    extern rb_node *nlopt_rb_tree_find(rb_tree * t, rb_key k);
+    extern rb_node *nlopt_rb_tree_find_le(rb_tree * t, rb_key k);
+    extern rb_node *nlopt_rb_tree_find_lt(rb_tree * t, rb_key k);
+    extern rb_node *nlopt_rb_tree_find_gt(rb_tree * t, rb_key k);
+    extern rb_node *nlopt_rb_tree_resort(rb_tree * t, rb_node * n);
+    extern rb_node *nlopt_rb_tree_min(rb_tree * t);
+    extern rb_node *nlopt_rb_tree_max(rb_tree * t);
+    extern rb_node *nlopt_rb_tree_succ(rb_node * n);
+    extern rb_node *nlopt_rb_tree_pred(rb_node * n);
+    extern void nlopt_rb_tree_shift_keys(rb_tree * t, ptrdiff_t kshift);
 
-/* To change a key, use rb_tree_find+resort.  Removing a node
+/* To change a key, use nlopt_rb_tree_find+resort.  Removing a node
    currently wastes memory unless you change the allocation scheme
    in redblack.c */
-    extern rb_node *rb_tree_remove(rb_tree * t, rb_node * n);
+    extern rb_node *nlopt_rb_tree_remove(rb_tree * t, rb_node * n);
 
 #ifdef __cplusplus
 }                               /* extern "C" */

--- a/src/util/redblack_test.c
+++ b/src/util/redblack_test.c
@@ -58,18 +58,18 @@ int main(int argc, char **argv)
 
     N = atoi(argv[1]);
     k = (int *) malloc(N * sizeof(int));
-    rb_tree_init(&t, comp);
+    nlopt_rb_tree_init(&t, comp);
 
     srand((unsigned) (argc > 2 ? atoi(argv[2]) : time(NULL)));
     for (i = 0; i < N; ++i) {
         double *newk = (double *) malloc(sizeof(double));
         *newk = (k[i] = rand() % N);
-        if (!rb_tree_insert(&t, newk)) {
-            fprintf(stderr, "error in rb_tree_insert\n");
+        if (!nlopt_rb_tree_insert(&t, newk)) {
+            fprintf(stderr, "error in nlopt_rb_tree_insert\n");
             return 1;
         }
-        if (!rb_tree_check(&t)) {
-            fprintf(stderr, "rb_tree_check_failed after insert!\n");
+        if (!nlopt_rb_tree_check(&t)) {
+            fprintf(stderr, "nlopt_rb_tree_check_failed after insert!\n");
             return 1;
         }
     }
@@ -81,34 +81,34 @@ int main(int argc, char **argv)
 
     for (i = 0; i < N; ++i) {
         kd = k[i];
-        if (!rb_tree_find(&t, &kd)) {
-            fprintf(stderr, "rb_tree_find lost %d!\n", k[i]);
+        if (!nlopt_rb_tree_find(&t, &kd)) {
+            fprintf(stderr, "nlopt_rb_tree_find lost %d!\n", k[i]);
             return 1;
         }
     }
 
-    n = rb_tree_min(&t);
+    n = nlopt_rb_tree_min(&t);
     for (i = 0; i < N; ++i) {
         if (!n) {
             fprintf(stderr, "not enough successors %d\n!", i);
             return 1;
         }
         printf("%d: %g\n", i, n->k[0]);
-        n = rb_tree_succ(n);
+        n = nlopt_rb_tree_succ(n);
     }
     if (n) {
         fprintf(stderr, "too many successors!\n");
         return 1;
     }
 
-    n = rb_tree_max(&t);
+    n = nlopt_rb_tree_max(&t);
     for (i = 0; i < N; ++i) {
         if (!n) {
             fprintf(stderr, "not enough predecessors %d\n!", i);
             return 1;
         }
         printf("%d: %g\n", i, n->k[0]);
-        n = rb_tree_pred(n);
+        n = nlopt_rb_tree_pred(n);
     }
     if (n) {
         fprintf(stderr, "too many predecessors!\n");
@@ -125,17 +125,17 @@ int main(int argc, char **argv)
         if (i >= N)
             abort();
         kd = k[i];
-        if (!(n = rb_tree_find(&t, &kd))) {
-            fprintf(stderr, "rb_tree_find lost %d!\n", k[i]);
+        if (!(n = nlopt_rb_tree_find(&t, &kd))) {
+            fprintf(stderr, "nlopt_rb_tree_find lost %d!\n", k[i]);
             return 1;
         }
         n->k[0] = knew;
-        if (!rb_tree_resort(&t, n)) {
-            fprintf(stderr, "error in rb_tree_resort\n");
+        if (!nlopt_rb_tree_resort(&t, n)) {
+            fprintf(stderr, "error in nlopt_rb_tree_resort\n");
             return 1;
         }
-        if (!rb_tree_check(&t)) {
-            fprintf(stderr, "rb_tree_check_failed after change %d!\n", N - M + 1);
+        if (!nlopt_rb_tree_check(&t)) {
+            fprintf(stderr, "nlopt_rb_tree_check_failed after change %d!\n", N - M + 1);
             return 1;
         }
         k[i] = -1 - knew;
@@ -153,9 +153,9 @@ int main(int argc, char **argv)
         rb_node *le, *gt;
         double lek, gtk;
         kd = 0.01 * (rand() % (N * 150) - N * 25);
-        le = rb_tree_find_le(&t, &kd);
-        gt = rb_tree_find_gt(&t, &kd);
-        n = rb_tree_min(&t);
+        le = nlopt_rb_tree_find_le(&t, &kd);
+        gt = nlopt_rb_tree_find_gt(&t, &kd);
+        n = nlopt_rb_tree_min(&t);
         lek = le ? le->k[0] : -HUGE_VAL;
         gtk = gt ? gt->k[0] : +HUGE_VAL;
         printf("%g <= %g < %g\n", lek, kd, gtk);
@@ -172,14 +172,14 @@ int main(int argc, char **argv)
             rb_node *succ = n;
             do {
                 n = succ;
-                succ = rb_tree_succ(n);
+                succ = nlopt_rb_tree_succ(n);
             } while (succ && succ->k[0] <= kd);
             if (n != le) {
-                fprintf(stderr, "rb_tree_find_le gave wrong result for k=%g\n", kd);
+                fprintf(stderr, "nlopt_rb_tree_find_le gave wrong result for k=%g\n", kd);
                 return 1;
             }
             if (succ != gt) {
-                fprintf(stderr, "rb_tree_find_gt gave wrong result for k=%g\n", kd);
+                fprintf(stderr, "nlopt_rb_tree_find_gt gave wrong result for k=%g\n", kd);
                 return 1;
             }
         }
@@ -194,15 +194,15 @@ int main(int argc, char **argv)
         if (i >= N)
             abort();
         kd = k[i];
-        if (!(n = rb_tree_find(&t, &kd))) {
-            fprintf(stderr, "rb_tree_find lost %d!\n", k[i]);
+        if (!(n = nlopt_rb_tree_find(&t, &kd))) {
+            fprintf(stderr, "nlopt_rb_tree_find lost %d!\n", k[i]);
             return 1;
         }
-        n = rb_tree_remove(&t, n);
+        n = nlopt_rb_tree_remove(&t, n);
         free(n->k);
         free(n);
-        if (!rb_tree_check(&t)) {
-            fprintf(stderr, "rb_tree_check_failed after remove!\n");
+        if (!nlopt_rb_tree_check(&t)) {
+            fprintf(stderr, "nlopt_rb_tree_check_failed after remove!\n");
             return 1;
         }
         k[i] = -1 - k[i];
@@ -213,7 +213,7 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    rb_tree_destroy(&t);
+    nlopt_rb_tree_destroy(&t);
     free(k);
 
     printf("SUCCESS.\n");


### PR DESCRIPTION
Collision was seen on NetBSD, ref:
http://mail-index.netbsd.org/tech-pkg/2020/10/11/msg023893.html

Fixes #360 