### PR TITLE
Avoid inclusion of .gitignore in the release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitignore export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
With this commit, the `.gitignore` file is not included in the release tarballs. Besides the fact that a .`gitignore` file is of no use in a release tarball, including such a file makes life a bit harder for the maintainers of downstream distributions.  For instance, Debian maintains most of its package in Git repositories and need to use their own `.gitignore.` file (see [the Debian repository for the nlopt package](https://salsa.debian.org/science-team/nlopt)).