### PR TITLE
cmake/FindGuile.cmake: Allow the detection of Guile 3.0

### DIFF
--- a/cmake/FindGuile.cmake
+++ b/cmake/FindGuile.cmake
@@ -18,6 +18,7 @@
 # Macports for OSX puts things in /opt/local
 find_path (GUILE_INCLUDE_DIR libguile.h
   PATH_SUFFIXES
+    guile/3.0
     guile/2.2
     guile/2.0
     guile/1.8
@@ -27,7 +28,7 @@ find_path (GUILE_INCLUDE_DIR libguile.h
 )
 
 # Look for the library
-find_library (GUILE_LIBRARY NAMES guile-2.2 guile-2.0 guile
+find_library (GUILE_LIBRARY NAMES guile-3.0 guile-2.2 guile-2.0 guile
   HINTS
     /opt/local/lib
 )


### PR DESCRIPTION
This allows building NLopt against Guile 3.0. The [example](https://nlopt.readthedocs.io/en/latest/NLopt_Tutorial/#example-in-gnu-guile-scheme) shown in the documentation runs fine with Guile 3.0.