### PR TITLE
Hessian preconditioner wrappers

### DIFF
--- a/src/swig/nlopt-exceptions.i
+++ b/src/swig/nlopt-exceptions.i
@@ -21,8 +21,11 @@
 %catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_max_objective(func f, void *f_data);
 %catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_max_objective(vfunc vf, void *f_data);
 
+%catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_precond_min_objective(func f, pfunc pf, void *f_data);
+
 %catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_min_objective(func f, void *f_data, nlopt_munge md, nlopt_munge mc);
 %catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_max_objective(func f, void *f_data, nlopt_munge md, nlopt_munge mc);
+%catches(std::bad_alloc,std::invalid_argument) nlopt::opt::set_precond_min_objective(func f, pfunc pf, void *f_data, nlopt_munge md, nlopt_munge mc);
 
 %catches(std::invalid_argument) nlopt::opt::remove_inequality_constraints();
 %catches(std::bad_alloc,std::invalid_argument) nlopt::opt::add_inequality_constraint(func f, void *f_data, double tol=0);


### PR DESCRIPTION
Closes #177

There's still an issue with the python wrappers. Seems to be passing the wrong number of arguments:

```
NotImplementedError: Wrong number or type of arguments for overloaded function 'opt_set_precond_min_objective'.
  Possible C/C++ prototypes are:
    nlopt::opt::set_precond_min_objective(nlopt::func,nlopt::pfunc,void *)
    nlopt::opt::set_precond_min_objective(nlopt::func,nlopt::pfunc,void *,nlopt_munge,nlopt_munge)
```

Any ideas what might be wrong?