### PR TITLE
Remove unnessary checks and defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,18 +98,10 @@ include (CheckLibraryExists)
 #==============================================================================
 # COMPILATION CHECKINGS and CONFIGURATION GENERATION
 #==============================================================================
-check_include_file (dlfcn.h HAVE_DLFCN_H)
 check_include_file (getopt.h HAVE_GETOPT_H)
 check_include_file (unistd.h HAVE_UNISTD_H)
-check_include_file (string.h HAVE_STRING_H)
-check_include_file (strings.h HAVE_STRINGS_H)
-check_include_file (inttypes.h HAVE_INTTYPES_H)
-check_include_file (memory.h HAVE_MEMORY_H)
-check_include_file (stdlib.h HAVE_STDLIB_H)
 check_include_file (stdint.h HAVE_STDINT_H)
 check_include_file (time.h HAVE_TIME_H)
-check_include_file (sys/types.h HAVE_SYS_TYPES_H)
-check_include_file (sys/stat.h HAVE_SYS_STAT_H)
 check_include_file (sys/time.h HAVE_SYS_TIME_H)
 if (HAVE_TIME_H AND HAVE_SYS_TIME_H)
   set (TIME_WITH_SYS_TIME TRUE)

--- a/nlopt_config.h.in
+++ b/nlopt_config.h.in
@@ -28,9 +28,6 @@
 /* Define if the copysign function/macro is available. */
 #cmakedefine HAVE_COPYSIGN
 
-/* Define to 1 if you have the <dlfcn.h> header file. */
-#cmakedefine HAVE_DLFCN_H
-
 /* Define if the fpclassify() function/macro is available. */
 #cmakedefine HAVE_FPCLASSIFY
 
@@ -49,9 +46,6 @@
 /* Define to 1 if you have the `gettimeofday' function. */
 #cmakedefine HAVE_GETTIMEOFDAY
 
-/* Define to 1 if you have the <inttypes.h> header file. */
-#cmakedefine HAVE_INTTYPES_H
-
 /* Define if the isinf() function/macro is available. */
 #cmakedefine HAVE_ISINF
 
@@ -61,29 +55,11 @@
 /* Define to 1 if you have the `m' library (-lm). */
 #undef HAVE_LIBM
 
-/* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H
-
 /* Define to 1 if you have the `qsort_r' function. */
 #cmakedefine HAVE_QSORT_R
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#cmakedefine HAVE_STDLIB_H
-
-/* Define to 1 if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H
-
-/* Define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#cmakedefine HAVE_SYS_STAT_H
-
-/* Define to 1 if you have the <sys/types.h> header file. */
-#cmakedefine HAVE_SYS_TYPES_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #cmakedefine HAVE_SYS_TIME_H


### PR DESCRIPTION
Apparently unused in the NLopt source code:
* `HAVE_DLFCN_H`.
* `HAVE_STRING_H`
* `HAVE_STRINGS_H`
* `HAVE_INTTYPES_H`
* `HAVE_MEMORY_H`
* `HAVE_STDLIB_H`
* `HAVE_SYS_TYPES_H`
* `HAVE_SYS_STAT_H`