### PR TITLE
CMake: Fix guile detection in Fedora

### DIFF
--- a/cmake/FindGuile.cmake
+++ b/cmake/FindGuile.cmake
@@ -64,11 +64,11 @@ if (GUILE_INCLUDE_DIR)
 endif ()
 
 find_program(GUILE_EXECUTABLE
-              NAMES guile
+              NAMES guile3.0 guile2.2 guile2.0 guile
            )
 
 find_program(GUILE_CONFIG_EXECUTABLE
-              NAMES guile-config
+              NAMES guile-config3.0 guile-config2.2 guile-config2.0 guile-config
            )
 
 


### PR DESCRIPTION
Add support for version-suffixed guile and guile-config as it's packaged
in Fedora (guile3.0, guile-config3.0 and guile2.2, guile-config2.2).