### PR TITLE
Improve octave test

### DIFF
--- a/test/t_octave.m
+++ b/test/t_octave.m
@@ -21,11 +21,11 @@ function [val, gradient] = myconstraint(x,a,b)
 endfunction
 
 
-opt.algorithm = NLOPT_LD_MMA
+opt.algorithm = NLOPT_LD_MMA;
 %  opt.algorithm = NLOPT_LN_COBYLA
-opt.lower_bounds = [-inf, 0]
-opt.min_objective = @myfunc
-opt.fc = { (@(x) myconstraint(x,2,0)), (@(x) myconstraint(x,-1,1)) }
+opt.lower_bounds = [-inf, 0];
+opt.min_objective = @myfunc;
+opt.fc = { (@(x) myconstraint(x,2,0)), (@(x) myconstraint(x,-1,1)) };
 opt.fc_tol = [1e-8, 1e-8];
-opt.xtol_rel = 1e-4
+opt.xtol_rel = 1e-4;
 [xopt, fmin, retcode] = nlopt_optimize(opt, [1.234 5.678])

--- a/test/t_octave.m
+++ b/test/t_octave.m
@@ -29,3 +29,7 @@ opt.fc = { (@(x) myconstraint(x,2,0)), (@(x) myconstraint(x,-1,1)) };
 opt.fc_tol = [1e-8, 1e-8];
 opt.xtol_rel = 1e-4;
 [xopt, fmin, retcode] = nlopt_optimize(opt, [1.234 5.678])
+
+assert (retcode, 4);
+assert (fmin, 0.5443, 1e-4);
+assert (xopt, [0.3333, 0.2963], 1e-4);


### PR DESCRIPTION
The output of the call to `nlopt_optimize` is verified using the `assert` function (https://github.com/rlaboiss/nlopt/commit/e3a1f29f3470bd812f09cbcbbee9b53391339fe1). This allows the detection of eventual problems when running the Octave unit test. Also, the code is made less verbose by adding semicolons to the end of the lines whose output is not informative (https://github.com/rlaboiss/nlopt/commit/8a2e87108176bddcc836f864d7230acf7109af74). 