### PR TITLE
Update latest version number on homepage

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -23,9 +23,9 @@ See the [NLopt Introduction](NLopt_Introduction.md) for a further overview of th
 Download and installation
 -------------------------
 
-Version 2.6.2 of NLopt is the latest version available from GitHub:
+Version 2.7.1 of NLopt is the latest version available from GitHub:
 
--   [v2.6.2.tar.gz](https://github.com/stevengj/nlopt/archive/v2.6.2.tar.gz)
+-   [v2.7.1.tar.gz](https://github.com/stevengj/nlopt/archive/v2.7.1.tar.gz)
 
 See the [NLopt release notes](https://github.com/stevengj/nlopt/blob/master/NEWS.md) for the release history. NLopt is designed to be installed on any Unix-like system (GNU/Linux is fine) with a C compiler, using the standard
 


### PR DESCRIPTION
👋 Hi there. I was recently integrating NLopt into a project I'm working on. Having started on the homepage (https://nlopt.readthedocs.io/en/latest/), I downloaded the suggested latest version which was 2.6.2. I later tried to use `nlopt::opt::set_param` but couldn't get it to compile, complaining that the function did not exist. It turns out that 2.6.2 is not the latest version but 2.7.1 is so I thought I could do with updating in the docs! I perhaps could have done some more digging, but the readthedocs site comes up on Google first for me.