### PR TITLE
Implement C++ style functors as targets for objectives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,12 +158,11 @@ endif ()
 if (NLOPT_CXX OR NLOPT_PYTHON OR NLOPT_GUILE OR NLOPT_OCTAVE)
   check_cxx_symbol_exists (__cplusplus ciso646 SYSTEM_HAS_CXX)
   if (SYSTEM_HAS_CXX)
-    check_cxx_compiler_flag ("-std=c++11" SUPPORTS_STDCXX11)
-    if (SUPPORTS_STDCXX11)
-      set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-      if (NLOPT_CXX)
-        set (NLOPT_CXX11 ON)
-      endif ()
+    set (CMAKE_CXX_STANDARD 11) # set the standard to C++11 but do not require it
+
+    if (NLOPT_CXX)
+      set (CMAKE_CXX_STANDARD_REQUIRED ON) # if we build C++ API, we do need C++11
+      set (NLOPT_CXX11 ON)
     endif ()
   else()
     message (FATAL_ERROR "The compiler doesn't support CXX.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,6 @@ if (NLOPT_CXX OR NLOPT_PYTHON OR NLOPT_GUILE OR NLOPT_OCTAVE)
 
     if (NLOPT_CXX)
       set (CMAKE_CXX_STANDARD_REQUIRED ON) # if we build C++ API, we do need C++11
-      set (NLOPT_CXX11 ON)
     endif ()
   else()
     message (FATAL_ERROR "The compiler doesn't support CXX.")
@@ -220,12 +219,27 @@ set (NLOPT_SOURCES
 )
 
 if (NLOPT_CXX)
-  list (APPEND NLOPT_SOURCES src/algs/stogo/global.cc src/algs/stogo/linalg.cc src/algs/stogo/local.cc src/algs/stogo/stogo.cc src/algs/stogo/tools.cc
-        src/algs/stogo/global.h src/algs/stogo/linalg.h src/algs/stogo/local.h src/algs/stogo/stogo_config.h src/algs/stogo/stogo.h src/algs/stogo/tools.h)
-endif ()
-if (NLOPT_CXX11)
-  list (APPEND NLOPT_SOURCES src/algs/ags/data_types.hpp src/algs/ags/evolvent.hpp src/algs/ags/evolvent.cc src/algs/ags/solver.hpp src/algs/ags/solver.cc
-  src/algs/ags/local_optimizer.hpp src/algs/ags/local_optimizer.cc src/algs/ags/ags.h src/algs/ags/ags.cc)
+  list (APPEND NLOPT_SOURCES
+    src/algs/stogo/global.cc
+    src/algs/stogo/linalg.cc
+    src/algs/stogo/local.cc
+    src/algs/stogo/stogo.cc
+    src/algs/stogo/tools.cc
+    src/algs/stogo/global.h
+    src/algs/stogo/linalg.h
+    src/algs/stogo/local.h
+    src/algs/stogo/stogo_config.h
+    src/algs/stogo/stogo.h
+    src/algs/stogo/tools.h
+    src/algs/ags/data_types.hpp
+    src/algs/ags/evolvent.hpp
+    src/algs/ags/evolvent.cc
+    src/algs/ags/solver.hpp
+    src/algs/ags/solver.cc
+    src/algs/ags/local_optimizer.hpp
+    src/algs/ags/local_optimizer.cc
+    src/algs/ags/ags.h
+    src/algs/ags/ags.cc)
 endif ()
 
 install (FILES ${NLOPT_HEADERS} DESTINATION ${RELATIVE_INSTALL_INCLUDE_DIR})

--- a/nlopt_config.h.in
+++ b/nlopt_config.h.in
@@ -129,9 +129,6 @@
 /* Define if compiled including C++-based routines */
 #cmakedefine NLOPT_CXX
 
-/* Define if compiled including C++11-based routines */
-#cmakedefine NLOPT_CXX11
-
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const
 

--- a/src/api/general.c
+++ b/src/api/general.c
@@ -46,9 +46,11 @@ static const char nlopt_algorithm_names[NLOPT_NUM_ALGORITHMS][256] = {
 #ifdef NLOPT_CXX
     "StoGO (global, derivative-based)",
     "StoGO with randomized search (global, derivative-based)",
+    "AGS (global, no-derivative)"
 #else
     "StoGO (NOT COMPILED)",
     "StoGO randomized (NOT COMPILED)",
+    "AGS (NOT COMPILED)"
 #endif
     "original L-BFGS code by Nocedal et al. (NOT COMPILED)",
     "Limited-memory BFGS (L-BFGS) (local, derivative-based)",
@@ -83,11 +85,6 @@ static const char nlopt_algorithm_names[NLOPT_NUM_ALGORITHMS][256] = {
     "Sequential Quadratic Programming (SQP) (local, derivative)",
     "CCSA (Conservative Convex Separable Approximations) with simple quadratic approximations (local, derivative)",
     "ESCH evolutionary strategy",
-#ifdef NLOPT_CXX11
-    "AGS (global, no-derivative)"
-#else
-    "AGS (NOT COMPILED)"
-#endif
 };
 
 const char *NLOPT_STDCALL nlopt_algorithm_name(nlopt_algorithm a)

--- a/src/api/nlopt-in.hpp
+++ b/src/api/nlopt-in.hpp
@@ -103,6 +103,24 @@ namespace nlopt {
       nlopt_munge munge_destroy, munge_copy; // non-NULL for SWIG wrappers
     } myfunc_data;
 
+    void* alloc_myfunc_data_with_nulls() {
+      // need to return void* otherwise SWIG doesn't compile because
+      // myfunc_data is private
+      myfunc_data *d = new myfunc_data;
+      if (!d) throw std::bad_alloc();
+
+      d->o             = this;
+      d->f             = NULL;
+      d->f_data        = NULL;
+      d->mf            = NULL;
+      d->vf            = NULL;
+      d->munge_destroy = NULL;
+      d->munge_copy    = NULL;
+
+      return reinterpret_cast<void*>(d);
+    }
+
+
     // free/destroy f_data in nlopt_destroy and nlopt_copy, respectively
     static void *free_myfunc_data(void *p) {
       myfunc_data *d = (myfunc_data *) p;
@@ -333,7 +351,8 @@ namespace nlopt {
       alloc_tmp();
     }
     void set_min_objective(functor_type functor) {
-      myfunc_data *d = alloc_myfunc_data_with_nulls();
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
 
       d->functor = std::move(functor);
       mythrow(nlopt_set_min_objective(o, functor_wrapper, d)); // d freed via o
@@ -355,25 +374,11 @@ namespace nlopt {
       alloc_tmp();
     }
     void set_max_objective(functor_type functor) {
-      myfunc_data *d = alloc_myfunc_data_with_nulls();
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
 
       d->functor = std::move(functor);
       mythrow(nlopt_set_max_objective(o, functor_wrapper, d)); // d freed via o
-    }
-
-    myfunc_data* alloc_myfunc_data_with_nulls() {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-
-      d->o             = this;
-      d->f             = NULL;
-      d->f_data        = NULL;
-      d->mf            = NULL;
-      d->vf            = NULL;
-      d->munge_destroy = NULL;
-      d->munge_copy    = NULL;
-
-      return d;
     }
 
     // for internal use in SWIG wrappers -- variant that

--- a/src/api/nlopt-in.hpp
+++ b/src/api/nlopt-in.hpp
@@ -106,17 +106,10 @@ namespace nlopt {
     void* alloc_myfunc_data_with_nulls() {
       // need to return void* otherwise SWIG doesn't compile because
       // myfunc_data is private
-      myfunc_data *d = new myfunc_data;
+      myfunc_data *d = new myfunc_data(); // zero-initialize all pointers
       if (!d) throw std::bad_alloc();
 
-      d->o             = this;
-      d->f             = NULL;
-      d->f_data        = NULL;
-      d->mf            = NULL;
-      d->vf            = NULL;
-      d->munge_destroy = NULL;
-      d->munge_copy    = NULL;
-
+      d->o = this;
       return reinterpret_cast<void*>(d);
     }
 

--- a/src/api/nlopt-in.hpp
+++ b/src/api/nlopt-in.hpp
@@ -103,21 +103,18 @@ namespace nlopt {
       nlopt_munge munge_destroy, munge_copy; // non-NULL for SWIG wrappers
     } myfunc_data;
 
-    static void* alloc_myfunc_data_with_nulls() {
-      // need to return void* otherwise SWIG doesn't compile because
-      // myfunc_data is private
+    static myfunc_data* alloc_myfunc_data_with_nulls() {
       myfunc_data *d = new myfunc_data(); // zero-initialize all pointers
       if (!d) throw std::bad_alloc();
 
-      return reinterpret_cast<void*>(d);
+      return d;
     }
 
-    void* alloc_and_init_myfunc_data() {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+    myfunc_data* alloc_and_init_myfunc_data() {
+      myfunc_data *d = alloc_myfunc_data_with_nulls();
 
       d->o = this;
-      return reinterpret_cast<void*>(d);
+      return d;
     }
 
 
@@ -140,8 +137,7 @@ namespace nlopt {
 	}
 	else
 	  f_data = d->f_data;
-        myfunc_data *dnew =
-          reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        myfunc_data *dnew = alloc_myfunc_data_with_nulls();
         *dnew = *d;
         dnew->f_data = f_data;
 	return (void*) dnew;
@@ -335,16 +331,14 @@ namespace nlopt {
 
     // Set the objective function
     void set_min_objective(func f, void *f_data) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f      = f;
       d->f_data = f_data;
 
       mythrow(nlopt_set_min_objective(o, myfunc, d)); // d freed via o
     }
     void set_min_objective(vfunc vf, void *f_data) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -352,24 +346,21 @@ namespace nlopt {
       alloc_tmp();
     }
     void set_min_objective(functor_type functor) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
-
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->functor = std::move(functor);
+
       mythrow(nlopt_set_min_objective(o, functor_wrapper, d)); // d freed via o
     }
 
     void set_max_objective(func f, void *f_data) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f      = f;
       d->f_data = f_data;
 
       mythrow(nlopt_set_max_objective(o, myfunc, d)); // d freed via o
     }
     void set_max_objective(vfunc vf, void *f_data) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -377,10 +368,9 @@ namespace nlopt {
       alloc_tmp();
     }
     void set_max_objective(functor_type functor) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
-
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->functor = std::move(functor);
+
       mythrow(nlopt_set_max_objective(o, functor_wrapper, d)); // d freed via o
     }
 
@@ -388,8 +378,7 @@ namespace nlopt {
     // takes ownership of f_data, with munging for destroy/copy
     void set_min_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -399,8 +388,7 @@ namespace nlopt {
     }
     void set_max_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -416,16 +404,14 @@ namespace nlopt {
       mythrow(ret);
     }
     void add_inequality_constraint(func f, void *f_data, double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f      = f;
       d->f_data = f_data;
 
       mythrow(nlopt_add_inequality_constraint(o, myfunc, d, tol));
     }
     void add_inequality_constraint(vfunc vf, void *f_data, double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -434,8 +420,7 @@ namespace nlopt {
     }
     void add_inequality_mconstraint(mfunc mf, void *f_data,
 				    const std::vector<double> &tol) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->mf     = mf;
       d->f_data = f_data;
 
@@ -448,16 +433,14 @@ namespace nlopt {
       mythrow(ret);
     }
     void add_equality_constraint(func f, void *f_data, double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f      = f;
       d->f_data = f_data;
 
       mythrow(nlopt_add_equality_constraint(o, myfunc, d, tol));
     }
     void add_equality_constraint(vfunc vf, void *f_data, double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -466,8 +449,7 @@ namespace nlopt {
     }
     void add_equality_mconstraint(mfunc mf, void *f_data,
 				  const std::vector<double> &tol) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->mf     = mf;
       d->f_data = f_data;
 
@@ -479,8 +461,7 @@ namespace nlopt {
     void add_inequality_constraint(func f, void *f_data,
 				   nlopt_munge md, nlopt_munge mc,
 				   double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -491,8 +472,7 @@ namespace nlopt {
     void add_equality_constraint(func f, void *f_data,
 				 nlopt_munge md, nlopt_munge mc,
 				 double tol=0) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -503,8 +483,7 @@ namespace nlopt {
     void add_inequality_mconstraint(mfunc mf, void *f_data,
 				    nlopt_munge md, nlopt_munge mc,
 				    const std::vector<double> &tol) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->mf            = mf;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -516,8 +495,7 @@ namespace nlopt {
     void add_equality_mconstraint(mfunc mf, void *f_data,
 				  nlopt_munge md, nlopt_munge mc,
 				  const std::vector<double> &tol) {
-      myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
+      myfunc_data *d = alloc_and_init_myfunc_data();
       d->mf            = mf;
       d->f_data        = f_data;
       d->munge_destroy = md;

--- a/src/api/nlopt-in.hpp
+++ b/src/api/nlopt-in.hpp
@@ -133,11 +133,10 @@ namespace nlopt {
 	}
 	else
 	  f_data = d->f_data;
-	myfunc_data *dnew = new myfunc_data;
-	if (dnew) {
-	  *dnew = *d;
-	  dnew->f_data = f_data;
-	}
+        myfunc_data *dnew =
+          reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        *dnew = *d;
+        dnew->f_data = f_data;
 	return (void*) dnew;
       }
       else return NULL;
@@ -329,17 +328,19 @@ namespace nlopt {
 
     // Set the objective function
     void set_min_objective(func f, void *f_data) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f      = f;
+      d->f_data = f_data;
+
       mythrow(nlopt_set_min_objective(o, myfunc, d)); // d freed via o
     }
     void set_min_objective(vfunc vf, void *f_data) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = NULL; d->f_data = f_data; d->mf = NULL; d->vf = vf;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->vf     = vf;
+      d->f_data = f_data;
+
       mythrow(nlopt_set_min_objective(o, myvfunc, d)); // d freed via o
       alloc_tmp();
     }
@@ -352,17 +353,19 @@ namespace nlopt {
     }
 
     void set_max_objective(func f, void *f_data) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f      = f;
+      d->f_data = f_data;
+
       mythrow(nlopt_set_max_objective(o, myfunc, d)); // d freed via o
     }
     void set_max_objective(vfunc vf, void *f_data) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = NULL; d->f_data = f_data; d->mf = NULL; d->vf = vf;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->vf     = vf;
+      d->f_data = f_data;
+
       mythrow(nlopt_set_max_objective(o, myvfunc, d)); // d freed via o
       alloc_tmp();
     }
@@ -378,18 +381,24 @@ namespace nlopt {
     // takes ownership of f_data, with munging for destroy/copy
     void set_min_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f             = f;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_set_min_objective(o, myfunc, d)); // d freed via o
     }
     void set_max_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f             = f;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_set_max_objective(o, myfunc, d)); // d freed via o
     }
 
@@ -400,26 +409,29 @@ namespace nlopt {
       mythrow(ret);
     }
     void add_inequality_constraint(func f, void *f_data, double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f      = f;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_inequality_constraint(o, myfunc, d, tol));
     }
     void add_inequality_constraint(vfunc vf, void *f_data, double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = NULL; d->f_data = f_data; d->mf = NULL; d->vf = vf;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->vf     = vf;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_inequality_constraint(o, myvfunc, d, tol));
       alloc_tmp();
     }
     void add_inequality_mconstraint(mfunc mf, void *f_data,
 				    const std::vector<double> &tol) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->mf = mf; d->f_data = f_data; d->f = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->mf     = mf;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_inequality_mconstraint(o, tol.size(), mymfunc, d,
 					       tol.empty() ? NULL : &tol[0]));
     }
@@ -429,26 +441,29 @@ namespace nlopt {
       mythrow(ret);
     }
     void add_equality_constraint(func f, void *f_data, double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f      = f;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_equality_constraint(o, myfunc, d, tol));
     }
     void add_equality_constraint(vfunc vf, void *f_data, double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = NULL; d->f_data = f_data; d->mf = NULL; d->vf = vf;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->vf     = vf;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_equality_constraint(o, myvfunc, d, tol));
       alloc_tmp();
     }
     void add_equality_mconstraint(mfunc mf, void *f_data,
 				  const std::vector<double> &tol) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->mf = mf; d->f_data = f_data; d->f = NULL; d->vf = NULL;
-      d->munge_destroy = d->munge_copy = NULL;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->mf     = mf;
+      d->f_data = f_data;
+
       mythrow(nlopt_add_equality_mconstraint(o, tol.size(), mymfunc, d,
 					     tol.empty() ? NULL : &tol[0]));
     }
@@ -457,38 +472,50 @@ namespace nlopt {
     void add_inequality_constraint(func f, void *f_data,
 				   nlopt_munge md, nlopt_munge mc,
 				   double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f             = f;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_add_inequality_constraint(o, myfunc, d, tol));
     }
     void add_equality_constraint(func f, void *f_data,
 				 nlopt_munge md, nlopt_munge mc,
 				 double tol=0) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->f = f; d->f_data = f_data; d->mf = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->f             = f;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_add_equality_constraint(o, myfunc, d, tol));
     }
     void add_inequality_mconstraint(mfunc mf, void *f_data,
 				    nlopt_munge md, nlopt_munge mc,
 				    const std::vector<double> &tol) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->mf = mf; d->f_data = f_data; d->f = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->mf            = mf;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_add_inequality_mconstraint(o, tol.size(), mymfunc, d,
 					       tol.empty() ? NULL : &tol[0]));
     }
     void add_equality_mconstraint(mfunc mf, void *f_data,
 				  nlopt_munge md, nlopt_munge mc,
 				  const std::vector<double> &tol) {
-      myfunc_data *d = new myfunc_data;
-      if (!d) throw std::bad_alloc();
-      d->o = this; d->mf = mf; d->f_data = f_data; d->f = NULL; d->vf = NULL;
-      d->munge_destroy = md; d->munge_copy = mc;
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+      d->mf            = mf;
+      d->f_data        = f_data;
+      d->munge_destroy = md;
+      d->munge_copy    = mc;
+
       mythrow(nlopt_add_equality_mconstraint(o, tol.size(), mymfunc, d,
 					     tol.empty() ? NULL : &tol[0]));
     }

--- a/src/api/nlopt-in.hpp
+++ b/src/api/nlopt-in.hpp
@@ -103,11 +103,18 @@ namespace nlopt {
       nlopt_munge munge_destroy, munge_copy; // non-NULL for SWIG wrappers
     } myfunc_data;
 
-    void* alloc_myfunc_data_with_nulls() {
+    static void* alloc_myfunc_data_with_nulls() {
       // need to return void* otherwise SWIG doesn't compile because
       // myfunc_data is private
       myfunc_data *d = new myfunc_data(); // zero-initialize all pointers
       if (!d) throw std::bad_alloc();
+
+      return reinterpret_cast<void*>(d);
+    }
+
+    void* alloc_and_init_myfunc_data() {
+      myfunc_data *d =
+        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
 
       d->o = this;
       return reinterpret_cast<void*>(d);
@@ -329,7 +336,7 @@ namespace nlopt {
     // Set the objective function
     void set_min_objective(func f, void *f_data) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f      = f;
       d->f_data = f_data;
 
@@ -337,7 +344,7 @@ namespace nlopt {
     }
     void set_min_objective(vfunc vf, void *f_data) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -346,7 +353,7 @@ namespace nlopt {
     }
     void set_min_objective(functor_type functor) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
 
       d->functor = std::move(functor);
       mythrow(nlopt_set_min_objective(o, functor_wrapper, d)); // d freed via o
@@ -354,7 +361,7 @@ namespace nlopt {
 
     void set_max_objective(func f, void *f_data) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f      = f;
       d->f_data = f_data;
 
@@ -362,7 +369,7 @@ namespace nlopt {
     }
     void set_max_objective(vfunc vf, void *f_data) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -371,7 +378,7 @@ namespace nlopt {
     }
     void set_max_objective(functor_type functor) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
 
       d->functor = std::move(functor);
       mythrow(nlopt_set_max_objective(o, functor_wrapper, d)); // d freed via o
@@ -382,7 +389,7 @@ namespace nlopt {
     void set_min_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -393,7 +400,7 @@ namespace nlopt {
     void set_max_objective(func f, void *f_data,
 			   nlopt_munge md, nlopt_munge mc) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -410,7 +417,7 @@ namespace nlopt {
     }
     void add_inequality_constraint(func f, void *f_data, double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f      = f;
       d->f_data = f_data;
 
@@ -418,7 +425,7 @@ namespace nlopt {
     }
     void add_inequality_constraint(vfunc vf, void *f_data, double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -428,7 +435,7 @@ namespace nlopt {
     void add_inequality_mconstraint(mfunc mf, void *f_data,
 				    const std::vector<double> &tol) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->mf     = mf;
       d->f_data = f_data;
 
@@ -442,7 +449,7 @@ namespace nlopt {
     }
     void add_equality_constraint(func f, void *f_data, double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f      = f;
       d->f_data = f_data;
 
@@ -450,7 +457,7 @@ namespace nlopt {
     }
     void add_equality_constraint(vfunc vf, void *f_data, double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->vf     = vf;
       d->f_data = f_data;
 
@@ -460,7 +467,7 @@ namespace nlopt {
     void add_equality_mconstraint(mfunc mf, void *f_data,
 				  const std::vector<double> &tol) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->mf     = mf;
       d->f_data = f_data;
 
@@ -473,7 +480,7 @@ namespace nlopt {
 				   nlopt_munge md, nlopt_munge mc,
 				   double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -485,7 +492,7 @@ namespace nlopt {
 				 nlopt_munge md, nlopt_munge mc,
 				 double tol=0) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->f             = f;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -497,7 +504,7 @@ namespace nlopt {
 				    nlopt_munge md, nlopt_munge mc,
 				    const std::vector<double> &tol) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->mf            = mf;
       d->f_data        = f_data;
       d->munge_destroy = md;
@@ -510,7 +517,7 @@ namespace nlopt {
 				  nlopt_munge md, nlopt_munge mc,
 				  const std::vector<double> &tol) {
       myfunc_data *d =
-        reinterpret_cast<myfunc_data*>(alloc_myfunc_data_with_nulls());
+        reinterpret_cast<myfunc_data*>(alloc_and_init_myfunc_data());
       d->mf            = mf;
       d->f_data        = f_data;
       d->munge_destroy = md;

--- a/src/api/optimize.c
+++ b/src/api/optimize.c
@@ -33,8 +33,6 @@
 
 #ifdef NLOPT_CXX
 #include "stogo.h"
-#endif
-#ifdef NLOPT_CXX11
 #include "ags.h"
 #endif
 
@@ -502,7 +500,7 @@ static nlopt_result nlopt_optimize_(nlopt_opt opt, double *x, double *minf)
         }
 
     case NLOPT_GN_AGS:
-#ifdef NLOPT_CXX11
+#ifdef NLOPT_CXX
         if (!finite_domain(n, lb, ub))
             RETURN_ERR(NLOPT_INVALID_ARGS, opt, "finite domain required for global algorithm");
         return ags_minimize(ni, f, f_data, opt->m, opt->fc, x, minf, lb, ub, &stop);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,18 @@
 add_custom_target (tests)
 
-add_executable (t_tutorial t_tutorial.cxx)
-target_link_libraries (t_tutorial ${nlopt_lib})
-add_dependencies (tests t_tutorial)
-target_include_directories (t_tutorial PRIVATE ${NLOPT_PRIVATE_INCLUDE_DIRS})
-add_test (NAME check_tutorial COMMAND t_tutorial)
-if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
-  set_tests_properties (check_tutorial PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
-endif ()
+macro(NLOPT_add_cpp_test test_name)
+  add_executable (${test_name} ${test_name}.cxx)
+  target_link_libraries (${test_name} ${nlopt_lib})
+  add_dependencies (tests ${test_name})
+  target_include_directories (${test_name} PRIVATE ${NLOPT_PRIVATE_INCLUDE_DIRS})
+  add_test (NAME check_${test_name} COMMAND ${test_name})
+  if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+    set_tests_properties (check_${test_name}
+      PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
+  endif ()
+endmacro()
+
+NLOPT_add_cpp_test(t_tutorial)
 
 # have to add timer.c and mt19937ar.c as symbols are declared extern
 set (testopt_sources testfuncs.c testfuncs.h testopt.c ${PROJECT_SOURCE_DIR}/src/util/timer.c ${PROJECT_SOURCE_DIR}/src/util/mt19937ar.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,8 +38,8 @@ foreach (algo_index RANGE 29)# 43
         set (enable_ FALSE)
       endif ()
     endif ()
-    # cxx11 ags
-    if (NOT NLOPT_CXX11 AND algo_index STREQUAL 43)
+    # cxx ags
+    if (NOT NLOPT_CXX AND algo_index STREQUAL 43)
       set (enable_ FALSE)
     endif ()
     # L-BFGS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ macro(NLOPT_add_cpp_test test_name)
 endmacro()
 
 NLOPT_add_cpp_test(t_tutorial)
+NLOPT_add_cpp_test(cpp_functor)
 
 # have to add timer.c and mt19937ar.c as symbols are declared extern
 set (testopt_sources testfuncs.c testfuncs.h testopt.c ${PROJECT_SOURCE_DIR}/src/util/timer.c ${PROJECT_SOURCE_DIR}/src/util/mt19937ar.c)

--- a/test/cpp_functor.cxx
+++ b/test/cpp_functor.cxx
@@ -1,0 +1,209 @@
+#include <iostream>
+#include <vector>
+#include <iomanip> // setprecision
+#include <string> // to_string
+#include <numeric> // inner_product
+#include <utility> // move
+#include <algorithm> // copy
+#include <cassert> // assert
+#include <cmath> // sin, cos
+
+#include <nlopt.hpp>
+
+typedef std::vector<double> Vector;
+
+class QuadraticForm {
+  /*
+   * This class represents a quadratic form (½ xᵀAx + bᵀx) and provides two
+   * methods to compute itself and its gradient.
+   *
+   * Input is always a (const double*) which has appropriate dimension.
+   */
+  private:
+    Vector A; // symmetric matrix
+    Vector b; // bias
+    size_t dimension;
+
+    Vector compute_A_times_x(const double* x) const
+    {
+      Vector A_times_x(dimension);
+      for (size_t row = 0; row < dimension; ++row) {
+        A_times_x[row] = dot(x, A, row * dimension);
+      }
+      return A_times_x;
+    }
+
+    double compute_quadratic_term(const double* x) const
+    {
+      auto A_times_x = compute_A_times_x(x);
+      return 0.5 * dot(x, A_times_x);
+    }
+
+    double compute_linear_term(const double* x) const
+    {
+      return dot(x, b);
+    }
+
+    double dot(const double* x, const Vector& y, const size_t offset = 0) const
+    {
+      return std::inner_product(
+          x,
+          x + dimension,
+          std::begin(y) + offset,
+          double(0));
+    }
+
+  public:
+    QuadraticForm() = delete;
+    QuadraticForm(Vector A_, Vector b_) :
+      A(std::move(A_)),
+      b(std::move(b_))
+    {
+      if (A.size() != b.size() * b.size()) {
+        throw std::runtime_error(
+            "[QuadraticForm] matrix and bias dimension mismatch: " +
+            std::to_string(A.size()) +
+            " != " +
+            std::to_string(b.size() * b.size()));
+      }
+      dimension = b.size();
+    }
+
+    double compute_form(const double* x) const
+    {
+      // ½ xᵀAx + bᵀx
+      return compute_quadratic_term(x) + compute_linear_term(x);
+    }
+
+    void compute_gradient_in_place(const double* x, double* grad_array) const
+    {
+      // matrix is assumed symmetric, hence gradient is (Ax + b)
+      Vector grad_vec = compute_A_times_x(x);
+
+      auto b_iterator = std::begin(b);
+      for (auto it = std::begin(grad_vec); it != std::end(grad_vec); ) {
+        *it++ += *b_iterator++;
+      }
+
+      std::copy(std::begin(grad_vec), std::end(grad_vec), grad_array);
+    }
+
+}; // QuadraticForm
+
+
+class LinearRegression {
+  private:
+    QuadraticForm quadratic_form;
+
+  public:
+    LinearRegression() = delete;
+    LinearRegression(QuadraticForm quadratic_form_) :
+      quadratic_form(std::move(quadratic_form_)) {}
+
+    double operator()(unsigned n, const double* x, double* grad) const
+    {
+      const double result = quadratic_form.compute_form(x);
+      if (!!grad) {
+        quadratic_form.compute_gradient_in_place(x, grad);
+      }
+
+      return result;
+    }
+}; // LinearRegression
+
+
+class SineRegression {
+  private:
+    QuadraticForm quadratic_form;
+
+  public:
+    SineRegression() = delete;
+    SineRegression(QuadraticForm quadratic_form_) :
+      quadratic_form(std::move(quadratic_form_)) {}
+
+    double operator()(unsigned n, const double* x, double* grad) const
+    {
+      const double form_result = quadratic_form.compute_form(x);
+      const double result = sin(form_result);
+
+      if (!!grad) {
+        const double grad_coefficient = cos(form_result);
+        quadratic_form.compute_gradient_in_place(x, grad);
+
+        for (size_t i = 0; i < n; ++i) {
+          grad[i] *= grad_coefficient;
+        }
+      }
+
+      return result;
+    }
+}; // SineRegression
+
+
+
+int main()
+{
+  // quadratic form is positive-definite for tau ∈ [-1, 2]
+  constexpr double tau = 1.5;
+  constexpr size_t dimension = 3;
+
+  Vector A = {
+      2,   -1,   tau,
+     -1,    2,    -1,
+    tau,   -1,     2 };
+  Vector b = { -3, 8, 1 };
+
+  assert(b.size() == dimension);
+  assert(A.size() == dimension * dimension);
+
+  QuadraticForm    form(std::move(A), std::move(b));
+  LinearRegression objective_1(form);
+  SineRegression   objective_2(std::move(form));
+
+  nlopt::opt optimizer("LD_MMA", dimension);
+  optimizer.set_xtol_rel(1e-4);
+  optimizer.set_maxeval(1000);
+
+
+  // linear regression optimization
+  optimizer.set_min_objective(std::move(objective_1));
+  double minimum = 0.0;
+  Vector x0 = {-1.0, 0.0, 0.1};
+
+  try {
+    optimizer.optimize(x0, minimum);
+  } catch (const std::exception& e) {
+    std::cerr << "NLopt failed: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "-- Linear regression --" << std::endl;
+  std::cout << "found minimum at f("
+    << x0[0] << ","
+    << x0[1] << ","
+    << x0[2] << ") = "
+    << std::setprecision(10) << minimum << std::endl << std::endl;
+
+
+  // sine regression optimization
+  optimizer.set_min_objective(std::move(objective_2));
+  minimum = 0.0;
+  x0 = {-1.0, 0.0, 0.1};
+
+  try {
+    optimizer.optimize(x0, minimum);
+  } catch (const std::exception& e) {
+    std::cerr << "NLopt failed: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::cout << "-- Sine regression --" << std::endl;
+  std::cout << "found minimum at f("
+    << x0[0] << ","
+    << x0[1] << ","
+    << x0[2] << ") = "
+    << std::setprecision(10) << minimum << std::endl;
+
+  return 0;
+}
+


### PR DESCRIPTION
This PR implements a wrapper `nlopt::functor_wrapper` for C++ style functors via `std::function`, and two new overloads of `nlopt::set_min_objective`, `nlopt::set_max_objective`.

In order to allow that, a new member field in the `myfunc_data` struct is added: `functor_type functor;`, where `functor_type` is defined as
```c++
typedef std::function<double(unsigned, const double*, double*)> functor_type;
```

This is not introduced as a pointer (like the other function-pointers are) because `std::function` is already a container that stores a pointer, and abstracts it away.

**Important:** note that the signature for the functor does not include `void* data` unlike all other function-pointers. That is because it is assumed that the functor already has all the data it needs.

This PR allows now to write the following:
```c++
class UserDefinedObjective {
  private:
    ImportantData data;
  public:
    UserDefinedObjective() = delete;
    UserDefinedObjective(ImportantData data) :
      data(std::move(data)) {}
    double operator()(unsigned n, const double* x, double* grad) const
    {
      // compute objective(x) and ∇objective(x) using this->data
    }
};

int main()
{
  ImportantData data;
  UserDefinedObjective objective(std::move(data));

  nlopt::opt optimizer;
  // other nlopt settings
  optimizer.set_max_objective(std::move(objective));

  optimizer.optimize(...);

  return 0;
}
```
Same with C++ lambdas, regular functions and even class member functions (check out [std::function](https://en.cppreference.com/w/cpp/utility/functional/function)).

This PR also introduces a CMake macro `NLOPT_add_cpp_test` to quickly add cpp tests, and creates a test `cpp_functor.cxx` to actually test the new functionality.

Closes #219 .