### PR TITLE
Only exit SLSQP successfully if solution is feasible

### DIFF
--- a/src/algs/slsqp/slsqp.c
+++ b/src/algs/slsqp/slsqp.c
@@ -2605,7 +2605,7 @@ nlopt_result nlopt_slsqp(unsigned n, nlopt_func f, void *f_data,
 	  /* note: mode == -1 corresponds to the completion of a line search,
 	     and is the only time we should check convergence (as in original slsqp code) */
 	  if (mode == -1) {
-	       if (!nlopt_isinf(fprev)) {
+	       if (!nlopt_isinf(fprev) && feasible) {
 		    if (nlopt_stop_ftol(stop, fcur, fprev))
 			 ret = NLOPT_FTOL_REACHED;
 		    else if (nlopt_stop_x(stop, xcur, xprev))


### PR DESCRIPTION
Previously, it could stop on ftol or xtol termination criteria, even if some constraints are still blatantly violated. This fixes #368.