### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ NLopt is compiled and installed with the [CMake](https://cmake.org/) build syste
 (To build the latest development sources from git, you will need [SWIG](http://www.swig.org/)
 to generate the Python and Guile bindings.)
 
+Alternatively, you can build and install NLopt using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nlopt
+
+The NLopt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Once it is installed, `#include <nlopt.h>` in your C/C++ programs and
 link it with `-lnlopt -lm`.  You may need to use a C++ compiler to link
 in order to include the C++ libraries (which are used internally by NLopt,

--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ NLopt is compiled and installed with the [CMake](https://cmake.org/) build syste
 (To build the latest development sources from git, you will need [SWIG](http://www.swig.org/)
 to generate the Python and Guile bindings.)
 
-Alternatively, you can build and install NLopt using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install nlopt
-
-The NLopt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
 Once it is installed, `#include <nlopt.h>` in your C/C++ programs and
 link it with `-lnlopt -lm`.  You may need to use a C++ compiler to link
 in order to include the C++ libraries (which are used internally by NLopt,

--- a/doc/docs/NLopt_Installation.md
+++ b/doc/docs/NLopt_Installation.md
@@ -76,6 +76,19 @@ cmake -DBUILD_SHARED_LIBS=OFF ..
 Then you run `make` and `make` `install` as usual.
 
 
+Vcpkg
+-------------------------
+
+Alternatively, you can build and install NLopt using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nlopt
+
+The NLopt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Octave and Matlab plugins
 -------------------------
 


### PR DESCRIPTION
`NLopt` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `NLopt` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `NLopt`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/nlopt/portfile.cmake). We try to keep the library maintained as close as possible to the original library.
