### PR TITLE
Remove equality constriant number check when adding constraint

### DIFF
--- a/src/api/options.c
+++ b/src/api/options.c
@@ -632,8 +632,6 @@ nlopt_result NLOPT_STDCALL nlopt_add_equality_mconstraint(nlopt_opt opt, unsigne
         ret = NLOPT_INVALID_ARGS;
     else if (!equality_ok(opt->algorithm))
         ret = ERR(NLOPT_INVALID_ARGS, opt, "invalid algorithm for constraints");
-    else if (nlopt_count_constraints(opt->p, opt->h) + m > opt->n)
-        ret = ERR(NLOPT_INVALID_ARGS, opt, "too many equality constraints");
     else
         ret = add_constraint(opt, &opt->p, &opt->p_alloc, &opt->h, m, NULL, fc, NULL, fc_data, tol);
     if (ret < 0 && opt && opt->munge_on_destroy)
@@ -649,8 +647,6 @@ nlopt_result NLOPT_STDCALL nlopt_add_precond_equality_constraint(nlopt_opt opt, 
         ret = NLOPT_INVALID_ARGS;
     else if (!equality_ok(opt->algorithm))
         ret = ERR(NLOPT_INVALID_ARGS, opt, "invalid algorithm for constraints");
-    else if (nlopt_count_constraints(opt->p, opt->h) + 1 > opt->n)
-        ret = ERR(NLOPT_INVALID_ARGS, opt, "too many equality constraints");
     else
         ret = add_constraint(opt, &opt->p, &opt->p_alloc, &opt->h, 1, fc, NULL, pre, fc_data, &tol);
     if (ret < 0 && opt && opt->munge_on_destroy)


### PR DESCRIPTION
Hi,

I have noticed that when the number of equality constraints exceeds the number of variables, NLOPT refuses to add them. However, this does not necessarily mean that there is no solution as there can be redundancy in the constraints that may be non-trivial to remove for the non-linear situation from the user side. Moreover, even if the number of equality constraints is less than the number of variables, this check cannot guarantee the solution's existence.  So this check seems not to make a lot of sense.

Therefore, I removed the check in this PR, or do you prefer a CMake option and preprocess directive that can conditionally disable it?