### PR TITLE
SLSQP search stopped too early on tutorial constraints

### DIFF
--- a/src/algs/slsqp/slsqp.c
+++ b/src/algs/slsqp/slsqp.c
@@ -2605,7 +2605,7 @@ nlopt_result nlopt_slsqp(unsigned n, nlopt_func f, void *f_data,
 	  /* note: mode == -1 corresponds to the completion of a line search,
 	     and is the only time we should check convergence (as in original slsqp code) */
 	  if (mode == -1) {
-	       if (!nlopt_isinf(fprev) && feasible) {
+	       if (!nlopt_isinf(fprev) && feasible_cur) {
 		    if (nlopt_stop_ftol(stop, fcur, fprev))
 			 ret = NLOPT_FTOL_REACHED;
 		    else if (nlopt_stop_x(stop, xcur, xprev))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,13 @@ foreach (algo_index RANGE 43)
         set (enable_ FALSE)
       endif ()
     endif ()
+    # 30 and 31 fail with NLOPT_ROUNDOFF_LIMITED depending on random starting point
+    if (algo_index STREQUAL 30)
+        set (enable_ FALSE)
+    endif ()
+    if (algo_index STREQUAL 31)
+        set (enable_ FALSE)
+    endif ()
     # cxx ags
     if (NOT NLOPT_CXX AND algo_index STREQUAL 43)
       set (enable_ FALSE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,7 +29,7 @@ if (NLOPT_CXX)
   set_target_properties(testopt PROPERTIES LINKER_LANGUAGE CXX)
 endif ()
 
-foreach (algo_index RANGE 29)# 43
+foreach (algo_index RANGE 43)
   foreach (obj_index RANGE 1)# 21
     set (enable_ TRUE)
     # cxx stogo
@@ -44,6 +44,10 @@ foreach (algo_index RANGE 29)# 43
     endif ()
     # L-BFGS
     if (algo_index STREQUAL 10)
+      set (enable_ FALSE)
+    endif ()
+    if (algo_index STREQUAL 36 OR algo_index STREQUAL 37
+        OR algo_index STREQUAL 38 OR algo_index STREQUAL 39)
       set (enable_ FALSE)
     endif ()
     if (enable_)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,7 +60,7 @@ foreach (algo_index RANGE 43)
       set (enable_ FALSE)
     endif ()
     if (enable_)
-      add_test (NAME testopt_algo${algo_index}_obj${obj_index} COMMAND testopt -r 0 -a ${algo_index} -o ${obj_index})
+      add_test (NAME testopt_algo${algo_index}_obj${obj_index} COMMAND testopt -r 0 -m 1e-3 -a ${algo_index} -o ${obj_index})
       if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
         set_tests_properties (testopt_algo${algo_index}_obj${obj_index} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
       endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,14 +5,16 @@ macro(NLOPT_add_cpp_test test_name)
   target_link_libraries (${test_name} ${nlopt_lib})
   add_dependencies (tests ${test_name})
   target_include_directories (${test_name} PRIVATE ${NLOPT_PRIVATE_INCLUDE_DIRS})
-  add_test (NAME check_${test_name} COMMAND ${test_name})
-  if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
-    set_tests_properties (check_${test_name}
-      PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
-  endif ()
+  foreach(arg IN ITEMS ${ARGN})
+      add_test (NAME check_${test_name}_${arg} COMMAND ${test_name} ${arg})
+      if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
+        set_tests_properties (check_${test_name}_${arg}
+          PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
+      endif ()
+  endforeach()
 endmacro()
 
-NLOPT_add_cpp_test(t_tutorial)
+NLOPT_add_cpp_test(t_tutorial 24 25 40)
 NLOPT_add_cpp_test(cpp_functor)
 
 # have to add timer.c and mt19937ar.c as symbols are declared extern
@@ -63,8 +65,11 @@ if (Python_FOUND AND NUMPY_FOUND AND (SWIG_FOUND OR (EXISTS ${PROJECT_SOURCE_DIR
   set (PYINSTALLCHECK_ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/src/swig"
                                   "PYTHONPATH=${PROJECT_BINARY_DIR}/src/swig"
     )
-  add_test (NAME test_python COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/t_python.py)
-  set_tests_properties (test_python PROPERTIES ENVIRONMENT "${PYINSTALLCHECK_ENVIRONMENT}")
+  # algorithms supporting inequality constraints and infinity bounds
+  foreach (algo_index 24 25 31 40)
+    add_test (NAME test_python${algo_index} COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/t_python.py ${algo_index})
+    set_tests_properties (test_python${algo_index} PROPERTIES ENVIRONMENT "${PYINSTALLCHECK_ENVIRONMENT}")
+  endforeach()
 endif ()
 
 if (OCTAVE_FOUND)

--- a/test/t_python.py
+++ b/test/t_python.py
@@ -2,6 +2,7 @@
 
 import nlopt
 import math as m
+import sys
 
 
 def myfunc(x, grad):
@@ -16,8 +17,9 @@ def myconstraint(x, grad, a, b):
         grad[1] = -1.0
     return (a*x[0] + b)**3 - x[1]
 
-opt = nlopt.opt(nlopt.LD_MMA, 2)
-opt.set_lower_bounds([-float('inf'), 0])
+algo = nlopt.LD_MMA if len(sys.argv) < 2 else int(sys.argv[1])
+opt = nlopt.opt(algo, 2)
+opt.set_lower_bounds([-float('inf'), 1e-6])
 opt.set_min_objective(myfunc)
 opt.add_inequality_constraint(lambda x, grad: myconstraint(x,grad, 2, 0), 1e-8)
 opt.add_inequality_constraint(lambda x, grad: myconstraint(x,grad, -1, 1), 1e-8)
@@ -30,3 +32,5 @@ print('minimum value = ', minf)
 print('result code = ', opt.last_optimize_result())
 print('nevals = ', opt.get_numevals())
 print('initial step =', opt.get_initial_step(x0))
+if m.fabs(minf - 0.5443310474) > 1e-3:
+    sys.exit(1)

--- a/test/t_tutorial.cxx
+++ b/test/t_tutorial.cxx
@@ -31,9 +31,8 @@ double myvconstraint(const std::vector<double> &x, std::vector<double> &grad, vo
 }
 
 
-int main() {
-
-  nlopt::opt opt("LD_MMA", 2);
+int main(int argc, char *argv[]) {
+  nlopt::opt opt(argc < 2 ? nlopt::LD_MMA : (nlopt::algorithm)atoi(argv[1]), 2);
   std::vector<double> lb(2);
   lb[0] = -HUGE_VAL; lb[1] = 0;
   opt.set_lower_bounds(lb);


### PR DESCRIPTION
I noticed that the python and C++ tutorials gave different answers when used with SLSQP:
    SLSQP was giving the wrong answer on the tutorial in 't_python.py':
    ```
    optimum at  [0.50777849 4.76252907]
    minimum value =  2.182321944309753
    ```
    instead of:
    ```
    optimum at  [0.33333333 0.29629629]
    minimum value =  0.5443310523133087
    ```


They are implemented slightly differently, using float multiplication vs `** 2` and `** 3`, which result in slightly different floating point values, however that shouldn't cause SLSQP to fail this badly.
The problem isn't with  the Python wrapper, because if I reimplement the same function for 'SciPy' it gives the correct answer.

After printing the individual 'f' evaluations I noticed that it stopped the search due to hitting 'xtol_rel', but the function was infeasible at that point (so it returned the last feasible one, which is way off the optimal value).
If I instead let the search continue until it finds a feasible point again then it finds the correct answer.
  
The problem was hinted to at https://github.com/stevengj/nlopt/issues/368#issuecomment-1196810479, which mentions that perhaps `feasible_cur` should be used, and I think as this example shows that would be the correct approach
(the original SLSQP fortran function also had a check for 'h3', which looks similar to the feasibility check done here).

While fixing the bug I also tweaked the tutorial function to accept the algorithm as parameter and run this during `make test` to check a few algorithms (those that accept inequality constraints and infinite bounds).