### PR TITLE
Use the anonymous namespace for a file-local class in stogo

### DIFF
--- a/src/algs/stogo/stogo.cc
+++ b/src/algs/stogo/stogo.cc
@@ -4,6 +4,7 @@
 #include "stogo.h"
 #include "global.h"
 
+namespace {
 class MyGlobal : public Global {
 protected:
   objective_func my_func;
@@ -25,6 +26,7 @@ public:
     return 0.0;
   }
 };
+}  // namespace
 
 int stogo_minimize(int n,
 		   objective_func fgrad, void *data,


### PR DESCRIPTION
BTW I saw that in `src/algs/ags/solver.cc` all of the code inside the anonymous was indented by an extra level.  Let me know if you'd like me to reformat this patch in the same way.