### PR TITLE
Fix include statement

### DIFF
--- a/doc/docs/NLopt_C-plus-plus_Reference.md
+++ b/doc/docs/NLopt_C-plus-plus_Reference.md
@@ -21,7 +21,7 @@ Compiling and linking your program to NLopt
 
 An NLopt program in C++ should include the NLopt C++ header file:
 
-`#include `<nlopt.hpp>
+`#include <nlopt.hpp>`
 
 On Unix, you would normally link your program exactly as for the C API, with a command something like:
 


### PR DESCRIPTION
Fixed a typo in the header include statement. Previously the name of the header was hidden because of incorrect markdown syntax.