### PR TITLE
Fix nlopt_algorithm_name

### DIFF
--- a/src/api/general.c
+++ b/src/api/general.c
@@ -46,11 +46,9 @@ static const char nlopt_algorithm_names[NLOPT_NUM_ALGORITHMS][256] = {
 #ifdef NLOPT_CXX
     "StoGO (global, derivative-based)",
     "StoGO with randomized search (global, derivative-based)",
-    "AGS (global, no-derivative)"
 #else
     "StoGO (NOT COMPILED)",
     "StoGO randomized (NOT COMPILED)",
-    "AGS (NOT COMPILED)"
 #endif
     "original L-BFGS code by Nocedal et al. (NOT COMPILED)",
     "Limited-memory BFGS (L-BFGS) (local, derivative-based)",
@@ -85,6 +83,11 @@ static const char nlopt_algorithm_names[NLOPT_NUM_ALGORITHMS][256] = {
     "Sequential Quadratic Programming (SQP) (local, derivative)",
     "CCSA (Conservative Convex Separable Approximations) with simple quadratic approximations (local, derivative)",
     "ESCH evolutionary strategy",
+#ifdef NLOPT_CXX
+    "AGS (global, no-derivative)",
+#else
+    "AGS (NOT COMPILED)",
+#endif
 };
 
 const char *NLOPT_STDCALL nlopt_algorithm_name(nlopt_algorithm a)


### PR DESCRIPTION
Fixes issues introduced in #457

There where missing commas at the end of `"AGS (global, no-derivative)"` causing it to be merged with the next string.
It's ordering was also changed without considering that the order of the items in the array mattered.

This PR fixes the ordering and makes sure that there are terminating commas for each entry.