### PR TITLE
Allow building NLOpt as permissive version without L-GPL licensed targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,16 @@ jobs:
           pip install mkdocs python-markdown-math --user
           PATH=$PATH:~/.local/bin mkdocs build
           mkdir build && pushd build
-          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_C_FLAGS='-std=c89 -pedantic -D_POSIX_C_SOURCE=200809L -Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
+          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DNLOPT_WITH_LUKSAN=ON -DCMAKE_C_FLAGS='-std=c89 -pedantic -D_POSIX_C_SOURCE=200809L -Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
           make install -j2 && ctest -j2 --output-on-failure
           rm -rf * ~/.local
-          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..
+          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DNLOPT_WITH_LUKSAN=OFF -DCMAKE_C_FLAGS='-std=c89 -pedantic -D_POSIX_C_SOURCE=200809L -Wall -Wextra' -DCMAKE_CXX_FLAGS='-Wall -Wextra' ..
+          make install -j2 && ctest -j2 --output-on-failure
+          rm -rf * ~/.local
+          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DNLOPT_WITH_LUKSAN=ON -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..
+          make install -j2
+          rm -rf * ~/.local
+          cmake -DCMAKE_INSTALL_PREFIX=~/.local -DNLOPT_PYTHON=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_FORTRAN=ON -DNLOPT_WITH_LUKSAN=OFF -DCMAKE_TOOLCHAIN_FILE=$PWD/../cmake/toolchain-x86_64-w64-mingw32.cmake ..
           make install -j2
 
   macos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ option (NLOPT_OCTAVE "build octave bindings" ON)
 option (NLOPT_MATLAB "build matlab bindings" ON)
 option (NLOPT_GUILE "build guile bindings" ON)
 option (NLOPT_SWIG "use SWIG to build bindings" ON)
+option (NLOPT_WITH_LUKSAN "Build NLOpt including L-GPL licensed 'Luksan' solver." ON)
 
 if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   option (NLOPT_TESTS "build unit tests" ON)
@@ -203,7 +204,6 @@ set (NLOPT_SOURCES
   src/algs/direct/DIRect.c src/algs/direct/direct_wrap.c src/algs/direct/DIRserial.c src/algs/direct/DIRsubrout.c src/algs/direct/direct-internal.h src/algs/direct/direct.h
   src/algs/cdirect/cdirect.c src/algs/cdirect/hybrid.c src/algs/cdirect/cdirect.h
   src/algs/praxis/praxis.c src/algs/praxis/praxis.h
-  src/algs/luksan/plis.c src/algs/luksan/plip.c src/algs/luksan/pnet.c src/algs/luksan/mssubs.c src/algs/luksan/pssubs.c src/algs/luksan/luksan.h
   src/algs/crs/crs.c src/algs/crs/crs.h
   src/algs/mlsl/mlsl.c src/algs/mlsl/mlsl.h
   src/algs/mma/mma.c src/algs/mma/mma.h src/algs/mma/ccsa_quadratic.c
@@ -218,10 +218,11 @@ set (NLOPT_SOURCES
   src/api/general.c src/api/options.c src/api/optimize.c src/api/deprecated.c src/api/nlopt-internal.h src/api/nlopt.h src/api/f77api.c src/api/f77funcs.h src/api/f77funcs_.h ${PROJECT_BINARY_DIR}/nlopt.hpp
   src/util/mt19937ar.c src/util/sobolseq.c src/util/soboldata.h src/util/timer.c src/util/stop.c src/util/nlopt-util.h src/util/redblack.c src/util/redblack.h src/util/qsort_r.c src/util/rescale.c
 )
-
-set_property(SOURCE src/algs/bobyqa/bobyqa.c src/algs/cdirect/hybrid.c src/algs/mma/ccsa_quadratic.c src/algs/cobyla/cobyla.c
-                    src/util/redblack.c src/algs/neldermead/nldrmd.c src/algs/newuoa/newuoa.c src/util/qsort_r.c
-	     PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+if(NLOPT_WITH_LUKSAN)
+  list(APPEND NLOPT_SOURCES
+    src/algs/luksan/plis.c src/algs/luksan/plip.c src/algs/luksan/pnet.c src/algs/luksan/mssubs.c src/algs/luksan/pssubs.c src/algs/luksan/luksan.h
+  )
+endif()
 
 if (NLOPT_CXX)
   list (APPEND NLOPT_SOURCES
@@ -246,6 +247,10 @@ if (NLOPT_CXX)
     src/algs/ags/ags.h
     src/algs/ags/ags.cc)
 
+set_property(SOURCE src/algs/bobyqa/bobyqa.c src/algs/cdirect/hybrid.c src/algs/mma/ccsa_quadratic.c src/algs/cobyla/cobyla.c
+                    src/util/redblack.c src/algs/neldermead/nldrmd.c src/algs/newuoa/newuoa.c src/util/qsort_r.c
+	     PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
+
 set_property(SOURCE src/algs/ags/solver.cc src/algs/ags/local_optimizer.cc src/algs/ags/ags.cc src/algs/slsqp/slsqp.c
              PROPERTY SKIP_UNITY_BUILD_INCLUSION ON)
 endif ()
@@ -255,8 +260,10 @@ install (FILES ${NLOPT_HEADERS} DESTINATION ${RELATIVE_INSTALL_INCLUDE_DIR})
 set (nlopt_lib nlopt)
 add_library (${nlopt_lib} ${NLOPT_SOURCES})
 add_dependencies(${nlopt_lib} generate-cpp)
+if(NLOPT_WITH_LUKSAN)
+  target_compile_definitions(${nlopt_lib} PRIVATE NLOPT_WITH_LUKSAN)
+endif()
 target_link_libraries (${nlopt_lib} ${M_LIBRARY})
-
 set_target_properties (${nlopt_lib} PROPERTIES SOVERSION ${SO_MAJOR})
 set_target_properties (${nlopt_lib} PROPERTIES VERSION "${SO_MAJOR}.${SO_MINOR}.${SO_PATCH}")
 
@@ -272,7 +279,6 @@ target_include_directories (${nlopt_lib} PRIVATE
   src/algs/direct
   src/algs/cdirect
   src/algs/praxis
-  src/algs/luksan
   src/algs/crs
   src/algs/mlsl
   src/algs/mma
@@ -284,7 +290,8 @@ target_include_directories (${nlopt_lib} PRIVATE
   src/algs/isres
   src/algs/slsqp
   src/algs/esch
-  src/api)
+  src/api
+  src/algs/luksan)
 
 get_target_property (NLOPT_PRIVATE_INCLUDE_DIRS ${nlopt_lib} INCLUDE_DIRECTORIES)
 target_include_directories (${nlopt_lib} INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/api;${PROJECT_BINARY_DIR}>" "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/COPYING
+++ b/COPYING
@@ -5,20 +5,19 @@ information of these packages.
 
 The compiled NLopt library, i.e. the combined work of all of the
 included optimization routines, is licensed under the conjunction of
-all of these licensing terms.  Currently, the most restrictive terms
+all of these licensing terms. By default, the most restrictive terms
 are for the code in the "luksan" directory, which is licensed under
 the GNU Lesser General Public License (GNU LGPL), version 2.1 or
-later (see luksan/COPYRIGHT).
-
-That means that the compiled NLopt library is governed by the terms of
-the LGPL.
+later (see luksan/COPYRIGHT). That means that, by default, the compiled
+NLopt library is governed by the terms of the LGPL.
 
 ---------------------------------------------------------------------------
 
-Other portions of NLopt, including any modifications to the abovementioned
-packages, are licensed under the standard "MIT License:"
+However, NLopt also offers the option to be built without the code in
+the "luksan" directory. In this case, NLopt, including any modifications
+to the abovementioned packages, are licensed under the standard "MIT License:"
 
-Copyright (c) 2007-2011 Massachusetts Institute of Technology
+Copyright (c) 2007-2024 Massachusetts Institute of Technology
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ NLopt is compiled and installed with the [CMake](https://cmake.org/) build syste
     make
     sudo make install
 
-(To build the latest development sources from git, you will need [SWIG](http://www.swig.org/)
-to generate the Python and Guile bindings.)
+To build NLopt as fully permissive library without LGPL-licensed "luksan" solvers, use `cmake -DNLOPT_WITH_LUKSAN=OFF ..`
+
+To build the latest development sources from git, you will need [SWIG](http://www.swig.org/)
+to generate the Python and Guile bindings.
 
 Once it is installed, `#include <nlopt.h>` in your C/C++ programs and
 link it with `-lnlopt -lm`.  You may need to use a C++ compiler to link

--- a/src/api/optimize.c
+++ b/src/api/optimize.c
@@ -38,7 +38,9 @@
 
 #include "cdirect.h"
 
+#ifdef NLOPT_WITH_LUKSAN
 #include "luksan.h"
+#endif
 
 #include "crs.h"
 
@@ -590,17 +592,32 @@ static nlopt_result nlopt_optimize_(nlopt_opt opt, double *x, double *minf)
         }
 
     case NLOPT_LD_LBFGS:
+#ifdef NLOPT_WITH_LUKSAN
         return luksan_plis(ni, f, f_data, lb, ub, x, minf, &stop, opt->vector_storage);
+#else
+        printf("ERROR - attempting to use 'luksan_plis', but not built with -DNLOPT_WITH_LUKSAN\n");
+        return NLOPT_INVALID_ARGS;
+#endif
 
     case NLOPT_LD_VAR1:
     case NLOPT_LD_VAR2:
+#ifdef NLOPT_WITH_LUKSAN
         return luksan_plip(ni, f, f_data, lb, ub, x, minf, &stop, opt->vector_storage, algorithm == NLOPT_LD_VAR1 ? 1 : 2);
+#else
+        printf("ERROR - attempting to use 'luksan_plip', but not build with -DNLOPT_WITH_LUKSAN\n");
+        return NLOPT_INVALID_ARGS;
+#endif
 
     case NLOPT_LD_TNEWTON:
     case NLOPT_LD_TNEWTON_RESTART:
     case NLOPT_LD_TNEWTON_PRECOND:
     case NLOPT_LD_TNEWTON_PRECOND_RESTART:
+#ifdef NLOPT_WITH_LUKSAN
         return luksan_pnet(ni, f, f_data, lb, ub, x, minf, &stop, opt->vector_storage, 1 + (algorithm - NLOPT_LD_TNEWTON) % 2, 1 + (algorithm - NLOPT_LD_TNEWTON) / 2);
+#else
+        printf("ERROR - attempting to use 'luksan_pnet', but not build with -DNLOPT_WITH_LUKSAN\n");
+        return NLOPT_INVALID_ARGS;
+#endif
 
     case NLOPT_GN_CRS2_LM:
         if (!finite_domain(n, lb, ub))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,13 @@ foreach (algo_index RANGE 29)# 43
       if (CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
         set_tests_properties (testopt_algo${algo_index}_obj${obj_index} PROPERTIES ENVIRONMENT "PATH=${PROJECT_BINARY_DIR}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")  # to load dll
       endif ()
+      # Check if LUKSAN targets are available.
+      if(NOT NLOPT_WITH_LUKSAN)
+        set(list_of_algorithms_requiring_luksan 11 12 13 14 15 16 17 18)
+        if(${algo_index} IN_LIST list_of_algorithms_requiring_luksan)
+          set_tests_properties(testopt_algo${algo_index}_obj${obj_index} PROPERTIES DISABLED TRUE)
+        endif()
+      endif()
     endif ()
   endforeach ()
 endforeach ()


### PR DESCRIPTION
Add option to compile NLOpt without luksan solver. The resulting library will be fully permissively licensed. If luksan is included, NLOpt remains L-GPL.