### PR TITLE
C++: Allow disabling exceptions in opt::optimize.

### DIFF
--- a/doc/docs/NLopt_Guile_Reference.md
+++ b/doc/docs/NLopt_Guile_Reference.md
@@ -230,7 +230,7 @@ You can call the following methods to retrieve the optimized objective function 
 ```
 
 
-The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), `optimize` throws an exception (see [Exceptions](#exceptions), below).
+The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), by default, `optimize` throws an exception (see [Exceptions](#exceptions), below).
 
 ### Return values
 
@@ -239,7 +239,7 @@ The possible return values are the same as the [return values in the C API](NLop
 Exceptions
 ----------
 
-The [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Guile API by thrown exceptions. The exception key takes the form of a Scheme symbol. The following exception keys are thrown by the various routines:
+If exceptions are enabled (the default), the [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Guile API by thrown exceptions. The exception key takes the form of a Scheme symbol. The following exception keys are thrown by the various routines:
 
 ```
 runtime-error
@@ -264,6 +264,15 @@ Halted because roundoff errors limited progress, equivalent to `NLOPT_ROUNDOFF_L
 
 `forced-stop` (subclass of `Exception`)
 Halted because of a forced termination: the user called `opt.force_stop()` from the user’s objective function. Equivalent to `NLOPT_FORCED_STOP`.
+
+Whether this behavior is enabled or whether `nlopt-opt-optimize` just returns the error code as is is controlled by the `enable_exceptions` flag in `nlopt::opt`, which can be set and retrieved with the methods below.
+
+```
+(nlopt-opt-set_exceptions_enabled opt enable)
+(nlopt-opt-get_exceptions_enabled opt)
+```
+
+The default is `#t` (true), i.e., to throw an exception. When setting `(nlopt-opt-set_exceptions_enabled opt #f)` (false), it is the caller's responsibility to *manually* check `(nlopt-opt-last-optimize-result opt)`. While that makes the `#f` setting more error-prone, it has the advantage that the best point found (which can be quite good even in some error cases) can still be returned through the return value of `nlopt-opt-optimize`, so is not lost, whereas if exceptions are enabled through `(nlopt-opt-set_exceptions_enabled opt #t)`, the exception prevents the best point from being returned.
 
 Currently, NLopt does not catch any exceptions that you might throw from your objective or constraint functions. (In the future, we might catch these exceptions, halt the optimization gracefully, and then re-throw, as in Python or C++, but this is not yet implemented.) So, throwing an exception in your objective/constraint may result in a memory leak.
 

--- a/doc/docs/NLopt_Java_Reference.md
+++ b/doc/docs/NLopt_Java_Reference.md
@@ -304,7 +304,7 @@ double opt_val = opt.lastOptimumValue();
 Result result = opt.lastOptimizeResult();
 ```
 
-The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), `optimize()` throws an exception (see [Exceptions](#exceptions), below).
+The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), by default, `optimize()` throws an exception (see [Exceptions](#exceptions), below).
 
 ### Return values
 
@@ -313,7 +313,7 @@ The possible return values are the same as the [return values in the C API](NLop
 Exceptions
 ----------
 
-The [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Java API by thrown exceptions. The following exceptions are thrown by the various routines:
+If exceptions are enabled (the default), the [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Java API by thrown exceptions. The following exceptions are thrown by the various routines:
 
 ```
 RuntimeException
@@ -339,7 +339,16 @@ Halted because roundoff errors limited progress, equivalent to `NLOPT_ROUNDOFF_L
 `nlopt.ForcedStopException` (subclass of `RuntimeException`)
 Halted because of a [forced termination](#forced-termination): the user called `opt.forceStop()` from the user’s objective function or threw an `nlopt.ForcedStop` exception. Equivalent to `NLOPT_FORCED_STOP`.
 
-If your objective/constraint functions throw *any* (runtime) exception during the execution of `opt.optimize`, it will be caught by NLopt and the optimization will be halted gracefully, and `opt.optimize` will re-throw the *same* exception to its caller. (Note that the Java compiler will not allow you to throw a checked exception from your callbacks, only a runtime exception.)
+Whether this behavior is enabled or whether `nlopt.Opt.optimize` just returns the error code as is is controlled by the `enableExceptions` flag in `nlopt.Opt`, which can be set and retrieved with the methods below.
+
+```java
+opt.setExceptionsEnabled(enable)
+opt.getExceptionsEnabled()
+```
+
+The default is `true`, i.e., to throw an exception. When setting `opt.setExceptionsEnabled(false)`, it is the caller's responsibility to *manually* check `opt.lastOptimizeResult()`. While that makes the `false` setting more error-prone, it has the advantage that the best point found (which can be quite good even in some error cases) can still be returned through the return value of `optimize`, so is not lost, whereas if exceptions are enabled through `opt.setExceptionsEnabled(true)`, the exception prevents the best point from being returned.
+
+If your objective/constraint functions throw *any* (runtime) exception during the execution of `opt.optimize`, it will be caught by NLopt and the optimization will be halted gracefully, and `opt.optimize` will re-throw the *same* exception to its caller. (Note that the Java compiler will not allow you to throw a checked exception from your callbacks, only a runtime exception.) For Java, the exception *will always* be rethrown, even if exceptions are otherwise disabled (`opt.setExceptionsEnabled(false)`).
 
 Local/subsidiary optimization algorithm
 ---------------------------------------

--- a/doc/docs/NLopt_Python_Reference.md
+++ b/doc/docs/NLopt_Python_Reference.md
@@ -268,7 +268,7 @@ opt_val = opt.last_optimum_value()
 result = opt.last_optimize_result()
 ```
 
-The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), `optimize()` throws an exception (see [Exceptions](#exceptions), below).
+The return code (see below) is positive on success, indicating the reason for termination. On failure (negative return codes), by default, `optimize()` throws an exception (see [Exceptions](#exceptions), below).
 
 ### Return values
 
@@ -277,7 +277,7 @@ The possible return values are the same as the [return values in the C API](NLop
 Exceptions
 ----------
 
-The [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Python API by thrown exceptions. The following exceptions are thrown by the various routines:
+If exceptions are enabled (the default), the [Error codes (negative return values)](NLopt_Reference.md#error-codes-negative-return-values) in the C API are replaced in the Python API by thrown exceptions. The following exceptions are thrown by the various routines:
 
 ```
 RunTimeError
@@ -303,7 +303,16 @@ Halted because roundoff errors limited progress, equivalent to `NLOPT_ROUNDOFF_L
 `nlopt.ForcedStop` (subclass of `Exception`)
 Halted because of a [forced termination](#forced-termination): the user called `opt.force_stop()` from the user’s objective function or threw an `nlopt.ForcedStop` exception. Equivalent to `NLOPT_FORCED_STOP`.
 
-If your objective/constraint functions throw *any* exception during the execution of `opt.optimize`, it will be caught by NLopt and the optimization will be halted gracefully, and `opt.optimize` will re-throw the *same* exception to its caller.
+Whether this behavior is enabled or whether `optimize` just returns the error code as is is controlled by the `enable_exceptions` flag in `nlopt.opt`, which can be set and retrieved with the methods below.
+
+```
+opt.set_exceptions_enabled(enable)
+opt.get_exceptions_enabled()
+```
+
+The default is `True`, i.e., to throw an exception. When setting `opt.set_exceptions_enabled(False)`, it is the caller's responsibility to *manually* check `opt.last_optimize_result()`. While that makes the `False` setting more error-prone, it has the advantage that the best point found (which can be quite good even in some error cases) can still be returned through the return value of `optimize`, so is not lost, whereas if exceptions are enabled through `opt.set_exceptions_enabled(True)`, the exception prevents the best point from being returned.
+
+If your objective/constraint functions throw *any* exception during the execution of `opt.optimize`, it will be caught by NLopt and the optimization will be halted gracefully, and `opt.optimize` will re-throw the *same* exception to its caller. For Python, the exception *will always* be rethrown, even if exceptions are otherwise disabled (`opt.set_exceptions_enabled(False)`).
 
 Local/subsidiary optimization algorithm
 ---------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ endmacro()
 NLOPT_add_cpp_test(t_tutorial 23 24 30 39)
 NLOPT_add_cpp_test(cpp_functor 0)
 NLOPT_add_cpp_test(t_fbound 0)
+NLOPT_add_cpp_test(t_except 1 0)
 
 NLOPT_add_cpp_test(t_bounded 0 1 2 3 4 5 6 7 8 18 34 41 42)
 if (NOT NLOPT_CXX)

--- a/test/t_except.cxx
+++ b/test/t_except.cxx
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cmath>
+#include <iomanip>
+#include <nlopt.hpp>
+
+/**
+ * Test exception handling. Contributed by Kevin Kofler <kofler@dagopt.com>.
+ * This tests a test case known to fail (t_bounded.cxx on LD_SLSQP) with
+ * set_exceptions_enabled set to true if the argument is 1, false if the
+ * argument is 0, and verifies that the exception is thrown resp. not thrown,
+ * as expected.
+ */
+
+double myvfunc(const std::vector<double> &x, std::vector<double> &grad, void *data)
+{
+  (void)data;
+  if (!grad.empty()) {
+    grad[0] = 2.0 * x[0];
+    grad[1] = 2.0 * x[1];
+  }
+  return x[0]*x[0]+x[1]*x[1];
+}
+
+int main(int argc, char *argv[]) {
+  nlopt::opt opt(nlopt::LD_SLSQP, 2);
+  if (argc >= 2) {
+    bool enable = (bool) atoi(argv[1]);
+    opt.set_exceptions_enabled(enable);
+    if (opt.get_exceptions_enabled() != enable) {
+      std::cerr << "set_exceptions_enabled(" << (enable ? "true" : "false")
+                << ") failed" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+  opt.set_lower_bounds(0.0);
+  opt.set_upper_bounds(1.0);
+  opt.set_max_objective(myvfunc, nullptr);
+  opt.set_maxeval(100000);
+  std::vector<double> x = {0.5, 0.5};
+  double minf = 0.0;
+  std::cout << "exceptions enabled: "
+            << (opt.get_exceptions_enabled() ? "true" : "false")
+            << std::endl;
+  try{
+    opt.optimize(x, minf);
+    std::cout << "no exception was thrown" << std::endl;
+    return opt.get_exceptions_enabled() ? EXIT_FAILURE : EXIT_SUCCESS;
+  }
+  catch(std::exception &e) {
+    std::cerr << "exception: " << e.what() << std::endl;
+    return opt.get_exceptions_enabled() ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+}
+


### PR DESCRIPTION
Call opt.set_exceptions_enabled(false) before opt.optimize to avoid throwing an exception. The caller is then responsible for checking the returned result or opt.last_result(). The advantage is that, for the SWIG-friendly overload, the returned best point (which can be quite good in, e.g., the roundoff_limited case) is not lost (but then the caller MUST check opt.last_result() to know whether anything has gone wrong). The default is exceptions_enabled=true, so by default, nothing changes.

src/api/nlopt-in.hpp (opt::exceptions_enabled): New private member variable.
(opt::opt (all overloads)): Initialize it (default it to true, copy it in the copy constructor).
(opt::operator=): Copy it.
(opt::optimize): Only call mythrow if exceptions_enabled. (get_exceptions_enabled): New public inline getter. (set_exceptions_enabled): New public inline setter.