### PR TITLE
CMake: Call project command before anything else

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@
 #==============================================================================
 cmake_minimum_required (VERSION 3.15)
 
-set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
-
 project (nlopt)
+
+set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
 
 #==============================================================================
 # version


### PR DESCRIPTION
Call the cmake project command before setting up any variables or calling any other cmake command to ensure that the language is properly set etc. Otherwise this can lead to weird behaviour such as seen here: https://gitlab.kitware.com/cmake/cmake/-/issues/22900