### PR TITLE
Add an internal parameter "outer_mineval_xftol" for mma/ccsaq.

### DIFF
--- a/src/algs/mma/ccsa_quadratic.c
+++ b/src/algs/mma/ccsa_quadratic.c
@@ -218,7 +218,7 @@ nlopt_result ccsa_quadratic_minimize(
      double *x, /* in: initial guess, out: minimizer */
      double *minf,
      nlopt_stopping *stop,
-     nlopt_opt dual_opt, int inner_maxeval, unsigned verbose, double rho_init,
+     nlopt_opt dual_opt, int inner_maxeval, int outer_mineval_xftol, unsigned verbose, double rho_init,
 	 const double *sigma_init)
 {
      nlopt_result ret = NLOPT_SUCCESS;
@@ -523,9 +523,9 @@ nlopt_result ccsa_quadratic_minimize(
 		    printf("                CCSA rhoc[%u] -> %g\n", i,rhoc[i]);
 	  }
 
-	  if (nlopt_stop_ftol(stop, fcur, fprev))
+	  if (k >= outer_mineval_xftol && nlopt_stop_ftol(stop, fcur, fprev))
 	       ret = NLOPT_FTOL_REACHED;
-	  if (nlopt_stop_x(stop, xcur, xprev))
+	  if (k >= outer_mineval_xftol && nlopt_stop_x(stop, xcur, xprev))
 	       ret = NLOPT_XTOL_REACHED;
 	  if (ret != NLOPT_SUCCESS) goto done;
 

--- a/src/algs/mma/mma.c
+++ b/src/algs/mma/mma.c
@@ -148,7 +148,7 @@ nlopt_result mma_minimize(unsigned n, nlopt_func f, void *f_data,
 			  double *x, /* in: initial guess, out: minimizer */
 			  double *minf,
 			  nlopt_stopping *stop,
-			  nlopt_opt dual_opt, int inner_maxeval, unsigned verbose, double rho_init,
+			  nlopt_opt dual_opt, int inner_maxeval, int outer_mineval_xftol, unsigned verbose, double rho_init,
 			  const double *sigma_init)
 {
      nlopt_result ret = NLOPT_SUCCESS;
@@ -375,9 +375,9 @@ nlopt_result mma_minimize(unsigned n, nlopt_func f, void *f_data,
 		    printf("                 MMA rhoc[%u] -> %g\n", i,rhoc[i]);
 	  }
 
-	  if (nlopt_stop_ftol(stop, fcur, fprev))
+	  if (k >= outer_mineval_xftol && nlopt_stop_ftol(stop, fcur, fprev))
 	       ret = NLOPT_FTOL_REACHED;
-	  if (nlopt_stop_x(stop, xcur, xprev))
+	  if (k >= outer_mineval_xftol && nlopt_stop_x(stop, xcur, xprev))
 	       ret = NLOPT_XTOL_REACHED;
 	  if (ret != NLOPT_SUCCESS) goto done;
 

--- a/src/algs/mma/mma.h
+++ b/src/algs/mma/mma.h
@@ -40,7 +40,7 @@ nlopt_result mma_minimize(unsigned n, nlopt_func f, void *f_data,
 			  double *x, /* in: initial guess, out: minimizer */
 			  double *minf,
 			  nlopt_stopping *stop,
-			  nlopt_opt dual_opt, int inner_maxeval, unsigned verbose, double rho_init,
+			  nlopt_opt dual_opt, int inner_maxeval, int outer_mineval_xftol, unsigned verbose, double rho_init,
                  const double *sigma_init);
 
 nlopt_result ccsa_quadratic_minimize(
@@ -53,7 +53,7 @@ nlopt_result ccsa_quadratic_minimize(
      double *x, /* in: initial guess, out: minimizer */
      double *minf,
      nlopt_stopping *stop,
-     nlopt_opt dual_opt, int inner_maxeval, unsigned verbose, double rho_init,
+     nlopt_opt dual_opt, int inner_maxeval, int outer_mineval_xftol, unsigned verbose, double rho_init,
      const double *sigma_init);
 
 #ifdef __cplusplus

--- a/src/api/optimize.c
+++ b/src/api/optimize.c
@@ -796,6 +796,7 @@ static nlopt_result nlopt_optimize_(nlopt_opt opt, double *x, double *minf)
     case NLOPT_LD_CCSAQ:
         {
             int inner_maxeval = (int)nlopt_get_param(opt, "inner_maxeval",0);
+			int outer_mineval_xftol = (int)nlopt_get_param(opt, "outer_mineval_xftol", 0);
             int verbosity = (int)nlopt_get_param(opt, "verbosity",0);
             double rho_init = nlopt_get_param(opt, "rho_init",1.0);
             nlopt_opt dual_opt;
@@ -817,9 +818,9 @@ static nlopt_result nlopt_optimize_(nlopt_opt opt, double *x, double *minf)
             nlopt_set_maxeval(dual_opt, (int)nlopt_get_param(opt, "dual_maxeval", LO(maxeval, 100000)));
 #undef LO
             if (algorithm == NLOPT_LD_MMA)
-                ret = mma_minimize(n, f, f_data, opt->m, opt->fc, lb, ub, x, minf, &stop, dual_opt, inner_maxeval, (unsigned)verbosity, rho_init, opt->dx);
+                ret = mma_minimize(n, f, f_data, opt->m, opt->fc, lb, ub, x, minf, &stop, dual_opt, inner_maxeval, outer_mineval_xftol, (unsigned)verbosity, rho_init, opt->dx);
             else
-                ret = ccsa_quadratic_minimize(n, f, f_data, opt->m, opt->fc, opt->pre, lb, ub, x, minf, &stop, dual_opt, inner_maxeval, (unsigned)verbosity, rho_init, opt->dx);
+                ret = ccsa_quadratic_minimize(n, f, f_data, opt->m, opt->fc, opt->pre, lb, ub, x, minf, &stop, dual_opt, inner_maxeval, outer_mineval_xftol, (unsigned)verbosity, rho_init, opt->dx);
             nlopt_destroy(dual_opt);
             return ret;
         }


### PR DESCRIPTION
In mma/ccsaq, when the outer iteration step k is less than "outer_mineval_xftol", the stopping criteria of xtol and ftol are disabled. This is quite useful in some optimization problems where there is a "startup" process during which x and f change slowly. The default value of "outer_mineval_xftol" is 0, namely the program behavior is the same with that of the current version.

	modified:   src/algs/mma/ccsa_quadratic.c
	modified:   src/algs/mma/mma.c
	modified:   src/algs/mma/mma.h
	modified:   src/api/optimize.c