### PR TITLE
slsqp: check ptot>n, not p>n (proper fix for #592)

### DIFF
--- a/src/algs/slsqp/slsqp.c
+++ b/src/algs/slsqp/slsqp.c
@@ -2459,7 +2459,7 @@ nlopt_result nlopt_slsqp(unsigned n, nlopt_func f, void *f_data,
      unsigned max_cdim;
      int want_grad = 1;
      
-     if (p > n) {
+     if (ptot > n) {
        nlopt_stop_msg(stop, "slsqp: more equality constraints than variables");
        return NLOPT_INVALID_ARGS;
      }


### PR DESCRIPTION
src/algs/slsqp/slsqp.c (src/algs/slsqp/slsqp.c): Fix the check for more equality constraints than variables (introduced by PR #593 to fix #592) so that vector constraints (mconstraints) are correctly counted: the count to consider here is ptot (the total number of scalar equality constraints), not p (the number of equality constraints that may be vector constraints).