### PR TITLE
nlopt: fix tests failing when luksan solvers are disabled

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,7 @@ foreach (algo_index RANGE 28) # 42
       endif ()
       # Check if LUKSAN targets are available.
       if (NOT NLOPT_LUKSAN)
-        set (list_of_algorithms_requiring_luksan 10 11 12 13 14 15 16 17)
+        set (list_of_algorithms_requiring_luksan 10 11 12 13 14 15 16 17 18)
         if (algo_index IN_LIST list_of_algorithms_requiring_luksan)
           set_tests_properties (testopt_algo${algo_index}_obj${obj_index} PROPERTIES DISABLED TRUE)
         endif()


### PR DESCRIPTION
There is an off-by-one error in the `test/CMakeLists.txt` that causes the tests to attempt to run disabled Luksan solver code, which in turn causes the test suite to fail:

```
Optimizing Rosenbrock function (2 dims) using Preconditioned truncated Newton with restarting (local, derivative-based) algorithm
lower bounds at lb = [ -2 -2]
upper bounds at ub = [ 2 2]
Starting guess x = [ 0.629447 0.811584]
Starting function value = 17.3914
ERROR - attempting to use NLOPT_LD_TNEWTON*, but Luksan code disabled
finished after 1.4e-05 seconds.
return code -2 from nlopt_minimize

      Start 59: testopt_algo19_obj1
52/77 Test #57: testopt_algo18_obj1 ..............***Failed    0.01 sec
testopt: error in nlopt_minimize
-----------------------------------------------------------
Optimizing McCormic function (2 dims) using Preconditioned truncated Newton with restarting (local, derivative-based) algorithm
lower bounds at lb = [ -1.5 -3]
upper bounds at ub = [ 4 4]
Starting guess x = [ 2.11549 1.92027]
Starting function value = 1.88587
ERROR - attempting to use NLOPT_LD_TNEWTON*, but Luksan code disabled
finished after 1.7e-05 seconds.
return code -2 from nlopt_minimize

97% tests passed, 2 tests failed out of 63
```