### PR TITLE
warning: null format string in stop.c

### DIFF
--- a/src/util/stop.c
+++ b/src/util/stop.c
@@ -185,6 +185,9 @@ void nlopt_eval_constraint(double *result, double *grad, const nlopt_constraint 
 
 char *nlopt_vsprintf(char *p, const char *format, va_list ap)
 {
+    if (!format)
+        abort();
+    
     size_t len = strlen(format) + 128;
     int ret;
 


### PR DESCRIPTION
`gcc-ubsan` and `gcc-asan` show

```bash
warning: null format string
```

occurring in `stop.c` specifically in function `nlopt_vsprintf()`.

According to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116834, the fix is to first check that the pointer to `format` is not null and abort if it is before calling `vsnprintf()`.